### PR TITLE
feat: Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Enable version updates for R/renv
+  - package-ecosystem: "renv"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Enable version updates for Python/pip
+  - package-ecosystem: "pip"
+    directory: "/Series_27/Analysis/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This commit adds a Dependabot configuration file (`.github/dependabot.yml`) to enable automatic dependency updates.

Dependabot is configured to:
- Check for R dependencies managed with `renv` in the root directory.
- Check for Python dependencies in `Series_27/Analysis/requirements.txt`.
- Check for updates on a daily schedule for both ecosystems.