### PR TITLE
Fix summary filename in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This script will:
 │   ├── Processed_Data/
 │   │   └── Year_YYYY (Yxx)_Data.xlsx # Processed Series 26 data per year (output of older scripts or specific S26 processing)
 │   └── Analysis/                     # Analysis summaries and logs for Series 26
-│       ├── Seatek_Analysis_Summary.xlsx
+│       ├── Seatek_Summary.xlsx
 │       ├── Seatek_Comprehensive_Analysis.xlsx
 │       ├── analysis_report_log.txt
 │       └── processing_log.txt
@@ -67,7 +67,7 @@ This script will:
 │       │   └── Year_YYYY (Yxx)_Data.xlsx #(example)
 │       ├── outlier_analysis_series27.py # Python script for S27 outlier detection and correction
 │       ├── Data_Validation_Report.xlsx
-│       ├── Seatek_Analysis_Summary.xlsx
+│       ├── Seatek_Summary.xlsx
 │       ├── Seatek_Comprehensive_Analysis.xlsx
 │       ├── analysis_report_log.txt
 │       ├── processing_log.txt


### PR DESCRIPTION
## Summary
- update old `Seatek_Analysis_Summary.xlsx` references to `Seatek_Summary.xlsx`

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat", stop_on_failure = TRUE)'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423b539ae88320835e9800bf5d9f3e