### PR TITLE
Fix lintr workflow

### DIFF
--- a/.github/workflows/lintr.yml
+++ b/.github/workflows/lintr.yml
@@ -24,6 +24,8 @@ jobs:
   lintr:
     name: Run lintr scanning
     runs-on: ubuntu-latest
+    env:
+      RENV_CONFIG_AUTOLOADER_ENABLED: "FALSE"
     permissions:
       contents: read
       security-events: write

--- a/README.md
+++ b/README.md
@@ -218,3 +218,8 @@ The linter configuration is currently the default provided by `lintr`. Key chang
 - Several style issues (line length, spacing, brace placement, etc.) were autofixed across project R files.
 - Some variable names in `Updated_Seatek_Analysis.R` (`headerStyle`, `highlightStyle`) were refactored to `header_style`, `highlight_style_yearly`, and `highlight_style_summary` for style consistency. These were internal changes to a function and are not expected to be breaking.
 - `lintr` currently flags potential `object_usage_linter` warnings for the 'Timestamp' variable within `data.table` assignments. These are believed to be false positives due to `data.table`'s non-standard evaluation and have been left as is for now.
+
+When running CI workflows where packages are installed manually (such as GitHub
+Actions), disable renv's autoloader to avoid interfering with `install.packages`
+by setting the environment variable `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE`.
+The provided `lintr` workflow already sets this variable.


### PR DESCRIPTION
## Summary
- disable renv autoloading during `lintr` workflow
- document how to disable renv autoload in CI

## Testing
- `Rscript -e 'print("test run")'`


------
https://chatgpt.com/codex/tasks/task_e_684239d1db0c8320bba28c1c92cb6d1d