### PR TITLE
Improve setup and test runner

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -22,7 +22,19 @@ fi
 
 # Restore R packages using renv
 echo "Restoring R packages with renv..."
-Rscript -e "if(!'renv' %in% rownames(installed.packages())) install.packages('renv', repos='https://cloud.r-project.org'); renv::restore()"
+Rscript -e "if(!'renv' %in% rownames(installed.packages())) install.packages('renv', repos='https://cloud.r-project.org'); renv::restore()" || echo "renv restore failed - proceeding with base install"
+
+# Install additional packages needed for linting and testing
+echo "Installing core R packages for linting and testing..."
+Rscript - <<'EOF'
+packages <- c('testthat', 'data.table', 'openxlsx', 'dplyr', 'tidyr', 'logger', 'lintr')
+install_if_missing <- function(pkg) {
+  if (!requireNamespace(pkg, quietly = TRUE)) {
+    install.packages(pkg, repos = 'https://cloud.r-project.org')
+  }
+}
+invisible(lapply(packages, install_if_missing))
+EOF
 
 # Setup Python virtual environment
 VENV_DIR="Series_27/Analysis/venv"

--- a/setup.sh
+++ b/setup.sh
@@ -22,7 +22,7 @@ fi
 
 # Restore R packages using renv
 echo "Restoring R packages with renv..."
-Rscript -e "if(!'renv' %in% rownames(installed.packages())) install.packages('renv', repos='https://cloud.r-project.org'); renv::restore()" || echo "renv restore failed - proceeding with base install"
+Rscript -e "if(!'renv' %in% rownames(installed.packages())) install.packages('renv', repos='https://cloud.r-project.org'); renv::restore()" > renv_restore.log 2>&1 || echo "renv restore failed - check renv_restore.log for details. Proceeding with base install."
 
 # Install additional packages needed for linting and testing
 echo "Installing core R packages for linting and testing..."

--- a/tests/testthat/testthat.R
+++ b/tests/testthat/testthat.R
@@ -13,11 +13,10 @@ if (!file.exists(script_path)) {
 }
 source(script_path) # Source the script to make functions available
 
-# Run all tests in the directory
-# If not a package, a more common way to run all tests in the dir is:
-# test_dir(".", stop_on_failure = TRUE)
-# Let's use test_dir for now as it's simpler for non-package structures.
-
-test_dir(".", stop_on_failure = TRUE)
-
-print("testthat.R executed: All tests in tests/testthat will be run.")
+# Run all tests in the directory when executed interactively
+# The workflow calls `testthat::test_dir()` externally, so we avoid
+# re-invoking it here to prevent nested calls and related errors.
+if (interactive()) {
+  test_dir(".", stop_on_failure = TRUE)
+  print("testthat.R executed: All tests in tests/testthat will be run.")
+}


### PR DESCRIPTION
## Summary
- only run `test_dir()` in interactive sessions to avoid nested invocations
- allow `setup.sh` to continue when `renv::restore()` fails and attempt to install basic R packages for linting/testing

## Testing
- `bash ./setup.sh` *(fails: renv restore errors and packages fail to install)*
- `R -q -e 'testthat::test_dir("tests/testthat", reporter="summary")'` *(fails: there is no package called 'testthat')*
- `R -q -e 'lintr::lint_dir(".")'` *(fails: there is no package called 'lintr')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6846405d592c83209210255546750e1e