### PR TITLE
Add unit tests for check_r_version in environment setup

### DIFF
--- a/implementation/scripts/01_environment_setup.R
+++ b/implementation/scripts/01_environment_setup.R
@@ -134,11 +134,11 @@ install_and_verify <- function(packages = REQUIRED_PACKAGES, cran_repo = CRAN_RE
 
 #' Check R version compatibility
 #' 
+#' @param r_version_data List containing R version information (defaults to R.version)
 #' @return List with success status and message
-check_r_version <- function() {
-  r_version <- R.version
-  major_version <- as.numeric(r_version$major)
-  minor_version <- as.numeric(r_version$minor)
+check_r_version <- function(r_version_data = R.version) {
+  major_version <- as.numeric(r_version_data$major)
+  minor_version <- as.numeric(r_version_data$minor)
   
   # Check if R version is >= 4.0.0
   if (major_version > 4 || (major_version == 4 && minor_version >= 0)) {
@@ -146,7 +146,7 @@ check_r_version <- function() {
   } else {
     return(list(
       success = FALSE, 
-      message = paste("R version", r_version$version.string, "is not compatible. Required: >= 4.0.0")
+      message = paste("R version", r_version_data$version.string, "is not compatible. Required: >= 4.0.0")
     ))
   }
 }
@@ -286,9 +286,9 @@ main_setup <- function() {
 }
 
 # Run setup if script is executed directly
-if (!interactive()) {
+if (sys.nframe() == 0 && !interactive()) {
   main_setup()
-} else {
+} else if (interactive()) {
   cat("Environment setup script loaded.\n")
   cat("Run main_setup() to execute the complete setup.\n")
 }

--- a/tests/testthat/test-check_r_version.R
+++ b/tests/testthat/test-check_r_version.R
@@ -1,0 +1,78 @@
+library(testthat)
+
+# Source the script containing the function
+# We assume the test is run with the working directory as 'tests/testthat'
+# or that we can find the file relative to the project root.
+# Let's try to robustly locate the file.
+
+script_rel_path <- "../../implementation/scripts/01_environment_setup.R"
+if (!file.exists(script_rel_path)) {
+  # Fallback if run from project root
+  script_rel_path <- "implementation/scripts/01_environment_setup.R"
+}
+
+if (!file.exists(script_rel_path)) {
+  stop("Could not locate 01_environment_setup.R")
+}
+
+source(script_rel_path)
+
+context("Environment Setup Checks")
+
+test_that("check_r_version returns success for compatible version", {
+  # Mock R version 4.0.0
+  mock_version <- list(
+    major = "4",
+    minor = "0.0",
+    version.string = "R version 4.0.0 (Mock)"
+  )
+
+  result <- check_r_version(mock_version)
+
+  expect_true(result$success)
+  expect_equal(result$message, "R version compatible")
+})
+
+test_that("check_r_version returns success for newer major version", {
+  # Mock R version 5.0.0
+  mock_version <- list(
+    major = "5",
+    minor = "0.0",
+    version.string = "R version 5.0.0 (Mock)"
+  )
+
+  result <- check_r_version(mock_version)
+
+  expect_true(result$success)
+})
+
+test_that("check_r_version returns failure for incompatible version", {
+  # Mock R version 3.6.3
+  mock_version <- list(
+    major = "3",
+    minor = "6.3",
+    version.string = "R version 3.6.3 (Mock)"
+  )
+
+  result <- check_r_version(mock_version)
+
+  expect_false(result$success)
+  expect_match(result$message, "is not compatible")
+})
+
+test_that("check_r_version handles current environment correctly", {
+  # This tests the default argument
+  result <- check_r_version()
+
+  expect_true(is.list(result))
+  expect_true("success" %in% names(result))
+  expect_true("message" %in% names(result))
+
+  # Check if result matches actual version check logic
+  current_r <- R.version
+  major <- as.numeric(current_r$major)
+  minor <- as.numeric(current_r$minor)
+  expected_success <- (major > 4) || (major == 4 && minor >= 0)
+
+  expect_equal(result$success, expected_success)
+})


### PR DESCRIPTION
Refactored `check_r_version` in `implementation/scripts/01_environment_setup.R` to allow dependency injection of the R version data, enabling robust unit testing.
Updated the script's execution guard to `if (sys.nframe() == 0 && !interactive())`, ensuring that `main_setup()` is only called when the script is executed directly, not when sourced by test files.
Added a new test file `tests/testthat/test-check_r_version.R` using `testthat` to verify:
- Compatibility with supported R versions (e.g., >= 4.0.0).
- Detection of incompatible R versions.
- Correct handling of the current environment's R version.

ELIR Handoff:
- **Purpose**: Enable unit testing of the environment setup script's R version check by decoupling it from the global `R.version` and preventing side effects when sourcing the file.
- **Security**: No security changes.
- **Fails if**: The `sys.nframe()` logic behaves differently in some R environments (unlikely in standard Rscript/interactive usage).
- **Verify**: Run `Rscript -e "testthat::test_file('tests/testthat/test-check_r_version.R')"` to confirm tests pass.
- **Maintain**: If R version compatibility requirements change (e.g., to R >= 4.1.0), update both the `check_r_version` function and the corresponding test mocks.

---
*PR created automatically by Jules for task [10358091824449559519](https://jules.google.com/task/10358091824449559519) started by @abhimehro*