### PR TITLE
Refactor dump_summary_excel into helper functions

### DIFF
--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -119,27 +119,26 @@ process_all_data <- function(data_dir) {
   results # Implicit return
 }
 
-# Write combined summary workbook
-dump_summary_excel <- function(results, output_file, highlight_top_n = 5) {
-  wb <- createWorkbook()
-  header_style <- createStyle(textDecoration = "bold")
-  # Write each year's sheet
-  for (year in names(results)) {
-    addWorksheet(wb, year)
-    df <- as.data.frame(results[[year]])
-    writeData(wb, sheet = year, x = df, rowNames = TRUE,
-              headerStyle = header_style)
-    freezePane(wb, sheet = year, firstRow = TRUE)
-    # Optional: highlight largest within_diff in each year
-    if ("within_diff" %in% colnames(df)) {
-      max_idx <- which.max(abs(df$within_diff))
-      highlight_style_yearly <- createStyle(bgFill = "#FFD700")
-      addStyle(wb, sheet = year, style = highlight_style_yearly,
-               rows = max_idx + 1,
-               cols = which(colnames(df) == "within_diff") + 1,
-               gridExpand = TRUE, stack = TRUE)
-    }
+# Write a single year's sheet to the workbook
+write_year_sheet <- function(wb, year, data, header_style) {
+  addWorksheet(wb, year)
+  df <- as.data.frame(data)
+  writeData(wb, sheet = year, x = df, rowNames = TRUE,
+            headerStyle = header_style)
+  freezePane(wb, sheet = year, firstRow = TRUE)
+  # Optional: highlight largest within_diff in each year
+  if ("within_diff" %in% colnames(df)) {
+    max_idx <- which.max(abs(df$within_diff))
+    highlight_style_yearly <- createStyle(bgFill = "#FFD700")
+    addStyle(wb, sheet = year, style = highlight_style_yearly,
+             rows = max_idx + 1,
+             cols = which(colnames(df) == "within_diff") + 1,
+             gridExpand = TRUE, stack = TRUE)
   }
+}
+
+# Compute summary statistics across all years
+calculate_summary_stats <- function(results) {
   # Add summary sheet with overall stats
   all_stats <- do.call(rbind, results)
   sensor_names <- rownames(all_stats)
@@ -179,6 +178,12 @@ dump_summary_excel <- function(results, output_file, highlight_top_n = 5) {
   summary_df$full_pct_nonmissing <-
     100 * summary_df$full_count / length(results)
 
+  summary_df # Implicit return
+}
+
+# Write summary sheets and CSVs
+write_summary_sheets <- function(wb, summary_df, output_file,
+                                 header_style, highlight_top_n) {
   # --- Comprehensive summary (all sensors) ---
   summary_df_all <- summary_df # keep a copy before filtering
   addWorksheet(wb, "Summary_All")
@@ -231,7 +236,8 @@ dump_summary_excel <- function(results, output_file, highlight_top_n = 5) {
       headerStyle = header_style
     )
     freezePane(wb, sheet = "Summary_Top_Sensors", firstRow = TRUE)
-    setColWidths(wb, sheet = "Summary_Top_Sensors", cols = 1:ncol(top_sensors), widths = "auto")
+    setColWidths(wb, sheet = "Summary_Top_Sensors", cols = 1:ncol(top_sensors),
+                 widths = "auto")
   }
 
   addWorksheet(wb, "Summary")
@@ -259,6 +265,21 @@ dump_summary_excel <- function(results, output_file, highlight_top_n = 5) {
   csv_robust <- sub("\\.xlsx$", "_robust.csv", output_file)
   write.csv(summary_df, csv_robust, row.names = FALSE)
   message(sprintf("Robust summary CSV written to %s", csv_robust))
+}
+
+# Write combined summary workbook
+dump_summary_excel <- function(results, output_file, highlight_top_n = 5) {
+  wb <- createWorkbook()
+  header_style <- createStyle(textDecoration = "bold")
+  # Write each year's sheet
+  for (year in names(results)) {
+    write_year_sheet(wb, year, results[[year]], header_style)
+  }
+  # Compute summary statistics
+  summary_df <- calculate_summary_stats(results)
+  # Write summary sheets and CSVs
+  write_summary_sheets(wb, summary_df, output_file,
+                       header_style, highlight_top_n)
 }
 
 # Main execution block


### PR DESCRIPTION
Extracted logic from `dump_summary_excel` in `Updated_Seatek_Analysis.R` into three helper functions: `write_year_sheet`, `calculate_summary_stats`, and `write_summary_sheets`.

This improves code readability and maintainability by reducing the complexity of the main function and separating concerns.

═════ ELIR ═════
PURPOSE: Improve code health by splitting a large function into smaller, focused helpers.
SECURITY: No security implications. Input handling remains the same.
FAILS IF: Helper function arguments are mismatched (verified via static analysis).
VERIFY: Run `tests/testthat/test-dump_summary_excel.R` to ensure output files are correct.
MAINTAIN: Future changes to summary calculation logic should be done in `calculate_summary_stats`.


---
*PR created automatically by Jules for task [4719412801223107525](https://jules.google.com/task/4719412801223107525) started by @abhimehro*