### PR TITLE
broom: Make implicit returns explicit in Updated_Seatek_Analysis.R

### DIFF
--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -34,7 +34,7 @@ auto_detect_data_dir <- function(data_dir) {
   if (missing(data_dir) || !dir.exists(data_dir)) {
     stop(sprintf("Data directory not found: %s", data_dir))
   }
-  normalizePath(data_dir)
+  return(normalizePath(data_dir))
 }
 
 # Read a single sensor data file
@@ -69,7 +69,7 @@ read_sensor_data <- function(file_path, sep = " ") {
   if (all(!is.na(as.numeric(dt$Timestamp)))) {
     dt[, Timestamp := as.POSIXct(as.numeric(Timestamp), origin = "1970-01-01")]
   }
-  dt # Implicit return
+  return(dt)
 }
 
 # Process all sensor files: export raw, compute metrics
@@ -116,7 +116,7 @@ process_all_data <- function(data_dir) {
       check.names = FALSE
     )
   }
-  results # Implicit return
+  return(results)
 }
 
 # Write combined summary workbook


### PR DESCRIPTION
**What:** Updated `read_sensor_data`, `process_all_data`, and `auto_detect_data_dir` in `Updated_Seatek_Analysis.R` to use explicit `return()` statements.
**Why:** To improve code readability, maintainability, and consistency.
**Verification:** Verified syntax by inspection. Runtime verification was skipped due to environment limitations (missing R), as authorized by the user.
**Result:** The functions now explicitly state what they return.

---
*PR created automatically by Jules for task [9044891169151417416](https://jules.google.com/task/9044891169151417416) started by @abhimehro*