### PR TITLE
🎨 Palette: Add `txtProgressBar` visual feedback to sensor data processing loop

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,3 @@
 ## 2025-05-06 - CLI Visual Feedback in Muffled Contexts
-**Learning:** In CLI applications (like R scripts) where standard output or message streams are suppressed or redirected (e.g., using `invokeRestart("muffleMessage")`), long-running iterations can appear frozen to the user. This creates poor UX and uncertainty.
+**Learning:** In CLI applications (like R scripts) where message conditions are muffled (e.g., `message()` output via `invokeRestart("muffleMessage")`) or standard output is suppressed or redirected, long-running iterations can appear frozen to the user. This creates poor UX and uncertainty.
 **Action:** When designing or refactoring long-running loops (like file processing), always inject visual feedback that bypasses or operates alongside standard streams, such as `txtProgressBar` in R, to ensure the user receives consistent progress updates.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-06 - CLI Visual Feedback in Muffled Contexts
+**Learning:** In CLI applications (like R scripts) where standard output or message streams are suppressed or redirected (e.g., using `invokeRestart("muffleMessage")`), long-running iterations can appear frozen to the user. This creates poor UX and uncertainty.
+**Action:** When designing or refactoring long-running loops (like file processing), always inject visual feedback that bypasses or operates alongside standard streams, such as `txtProgressBar` in R, to ensure the user receives consistent progress updates.

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -83,6 +83,7 @@ process_all_data <- function(data_dir) {
   }
   results <- list()
   pb <- txtProgressBar(min = 0, max = length(files), style = 3)
+  on.exit(close(pb), add = TRUE)
   i <- 0
   for (f in files) {
     df <- read_sensor_data(f)

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -82,6 +82,8 @@ process_all_data <- function(data_dir) {
     stop(sprintf("No sensor files found matching %s in %s", pattern, data_dir))
   }
   results <- list()
+  pb <- txtProgressBar(min = 0, max = length(files), style = 3)
+  i <- 0
   for (f in files) {
     df <- read_sensor_data(f)
     # Export raw data to Excel
@@ -116,7 +118,10 @@ process_all_data <- function(data_dir) {
       row.names = sensor_names,
       check.names = FALSE
     )
+    i <- i + 1
+    setTxtProgressBar(pb, i)
   }
+  close(pb)
   return(results)
 }
 


### PR DESCRIPTION
💡 **What:** Added a `txtProgressBar` to the `process_all_data` function in `Updated_Seatek_Analysis.R`. It tracks iterations over the data files.

🎯 **Why:** `Updated_Seatek_Analysis.R` currently suppresses its message stream using `invokeRestart("muffleMessage")` at the top level. Without visual feedback, the user might assume the script is frozen when processing a large number of sensor files in the loop. The `txtProgressBar` bypasses the `muffleMessage` trap and outputs safely to the console.

♿ **Accessibility / DX:** Reduces user uncertainty by providing clear visual feedback on processing status. Prevents premature termination of long-running data processing workflows by users who think the CLI is stuck. This aligns with standard R script development best practices.

**Note:** Tests in `tests/testthat/test-process_all_data.R` pass smoothly because progress bar logic has no side-effects on data returned or file handles created. I also created `.jules/palette.md` to ensure future agents maintain awareness of CLI feedback best practices in buffered/muffled contexts.

---
*PR created automatically by Jules for task [3406215271705934692](https://jules.google.com/task/3406215271705934692) started by @abhimehro*