### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal regex and file matching bugs

### DIFF
--- a/implementation/scripts/02_backup_system.R
+++ b/implementation/scripts/02_backup_system.R
@@ -57,7 +57,7 @@ restore_backup <- function(backup_file, restore_dir = getwd()) {
     # - UNC paths like '\\server\share\...'
     # - Any '..' traversal using either '/' or '\' as a separator
     pattern <- "^(?:/|[A-Za-z]:[\\\\/]|\\\\\\\\)|(^|[\\\\/])\\.\\.(?:[\\\\/]|$)"
-    if (any(grepl(pattern, contents))) {
+    if (any(grepl(pattern, contents, perl = TRUE))) {
       stop("Security Error: Backup archive contains absolute paths or path traversal patterns.")
     }
 
@@ -84,7 +84,7 @@ list_backups <- function(backup_dir = "backups") {
       message(sprintf("Backup directory does not exist: %s", backup_dir))
       return(data.frame())
     }
-    files <- list.files(backup_dir, pattern = "\.tar\.gz$", full.names = TRUE)
+    files <- list.files(backup_dir, pattern = "\\.tar\\.gz$", full.names = TRUE)
     if (length(files) == 0) {
       message("No backups found.")
       return(data.frame())
@@ -114,7 +114,7 @@ cleanup_old_backups <- function(backup_dir = "backups", days_to_keep = 30) {
       message(sprintf("Backup directory does not exist: %s", backup_dir))
       return(character(0))
     }
-    files <- list.files(backup_dir, pattern = "\.tar\.gz$", full.names = TRUE)
+    files <- list.files(backup_dir, pattern = "\\.tar\\.gz$", full.names = TRUE)
     if (length(files) == 0) {
       message("No backups to clean up.")
       return(character(0))


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix path traversal regex and file matching bugs

🚨 Severity: HIGH
💡 Vulnerability: The path traversal regex `^(?:/|[A-Za-z]:[\\/]|\\\\)|(^|[\\/])\.\.(?:[\\/]|$)` was not evaluated correctly by R's default POSIX ERE engine because non-capturing groups `(?:...)` require PCRE. This caused the path traversal check during tar extraction to silently fail, allowing potential Tar Slip attacks. Additionally, `list.files` was using unescaped dots `\.tar\.gz$`, which is a syntax error in R strings.
🎯 Impact: An attacker could craft a malicious backup archive that overwrites sensitive files outside the restore directory.
🔧 Fix:
- Added `perl = TRUE` to `grepl()` to ensure the regex accurately evaluates `(?:...)` logic.
- Escaped `\.tar\.gz$` to `\\.tar\\.gz$` to properly filter backup lists without matching unintended files.
✅ Verification: Tested regex with `perl = TRUE` locally. Syntax verified via reading the patched file.

---
*PR created automatically by Jules for task [17793363512519309700](https://jules.google.com/task/17793363512519309700) started by @abhimehro*