### PR TITLE
🛡️ Sentinel: [HIGH] Fix GitHub Actions Secret Interpolation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -32,11 +32,13 @@ jobs:
 
       - name: Generate changelog
         # Pass the built-in GITHUB_TOKEN explicitly using the --token flag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           github_changelog_generator \
             --user "${GITHUB_REPOSITORY_OWNER}" \
             --project "${GITHUB_REPOSITORY#*/}" \
-            --token "${{ secrets.GITHUB_TOKEN }}"
+            --token "${GITHUB_TOKEN}"
 
       - name: Commit and Push Changes
         run: |

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Untrusted AI-generated output was interpolated directly into a bash command (`gh issue comment $ISSUE_NUMBER --body '${{ steps.inference.outputs.response }}'`) in a GitHub Actions workflow.
 **Learning:** Using `${{ ... }}` interpolation within `run` blocks in GitHub Actions can lead to command injection if the content is malicious, as the string is evaluated before the script executes. This applies to user input, issue bodies, and AI outputs.
 **Prevention:** Always pass untrusted data to shell scripts via environment variables (e.g., `env:` block mapping to `$VARIABLE_NAME`) rather than direct inline string interpolation.
+
+## 2025-08-02 - GitHub Actions Secret Interpolation
+**Vulnerability:** A GitHub secret (`${{ secrets.GITHUB_TOKEN }}`) was interpolated directly into a bash command (`--token "${{ secrets.GITHUB_TOKEN }}"`) in a GitHub Actions workflow (`changelog.yml`).
+**Learning:** While secrets are not necessarily user-controlled, direct interpolation of secrets within `run` blocks is a dangerous pattern. If a secret contains shell metacharacters or quotes, it could cause syntax errors or unintended command execution. Furthermore, it normalizes an insecure pattern that might be copied for untrusted inputs.
+**Prevention:** Always pass secrets to shell scripts securely by mapping them to environment variables (e.g., using an `env:` block `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`) and referencing the environment variable (`$GITHUB_TOKEN`) in the script.


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix GitHub Actions Secret Interpolation

🚨 **Severity:** HIGH
💡 **Vulnerability:** Direct interpolation of `${{ secrets.GITHUB_TOKEN }}` inside a `run` block in `.github/workflows/changelog.yml` exposes the workflow to potential injection and parsing risks if the secret contains shell metacharacters.
🎯 **Impact:** This violates GitHub Actions best practices. Although `GITHUB_TOKEN` is generated and generally safe, allowing inline interpolation normalizes an insecure pattern that could lead to severe command injection if copied for user-controlled inputs.
🔧 **Fix:** Moved the secret to the `env:` block as `GITHUB_TOKEN` and updated the `run` script to safely use the environment variable (`$GITHUB_TOKEN`).
✅ **Verification:** The workflow file is valid YAML and the inline interpolation has been completely removed. Recorded the finding in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5364397758031330136](https://jules.google.com/task/5364397758031330136) started by @abhimehro*