### PR TITLE
⚡ Bolt: Optimize metric aggregations with data.table native operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-05-06 - Prevent Re-parsing Excel Files in Loops
 **Learning:** `pd.read_excel(file_path, sheet_name=sheet)` re-parses the entire zip-like structure of the `.xlsx` file from scratch every single time it's called. When looping over multiple sheets in the same file, this becomes an O(N * M) operation (where N is sheets and M is file size).
 **Action:** When reading multiple sheets from the same Excel file inside a loop, always instantiate a `pd.ExcelFile(file_path)` object outside the loop first, and use `pd.read_excel(xls, sheet_name=sheet)` inside the loop. This reduces the parsing overhead to O(M).
+
+## 2025-05-06 - Avoid Repeated Column Subsetting in data.table
+**Learning:** Using `sapply(df[, cols, with=FALSE], ...)` combined with row-based subsetting functions inside the loop like `head(x, N)` forces the creation of a subset `data.frame` first, then sequentially traverses each column and slices it. For large rows/columns, this is an O(M * N) operation.
+**Action:** Use data.table's native optimized `i` row filters along with `.SDcols` (e.g., `df[1:10, lapply(.SD, function), .SDcols = cols]`). This subsets the rows once in C (O(1) operation), and evaluates the function seamlessly across all targets, drastically reducing memory allocation and iteration cost.

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -103,12 +103,12 @@ process_all_data <- function(data_dir) {
     # OPTIMIZATION: which(x > 0) is natively faster at dropping NAs than !is.na() &
     clean_vals <- function(x) x[which(x > 0)]
     sensor_names <- grep("^Sensor", names(df), value = TRUE)
-    first10 <- sapply(df[, ..sensor_names],
-                      function(x) mean(clean_vals(head(x, 10))))
-    last5  <- sapply(df[, ..sensor_names],
-                     function(x) mean(clean_vals(tail(x, 5))))
-    full   <- sapply(df[, ..sensor_names], function(x) mean(clean_vals(x)))
-    diff   <- full - first10
+
+    # ⚡ Bolt: Replace sapply with data.table native lapply(.SD) for O(1) row subsetting
+    first10 <- unlist(df[1:min(10, .N), lapply(.SD, function(x) mean(clean_vals(x))), .SDcols = sensor_names])
+    last5   <- unlist(df[max(1, .N - 4):.N, lapply(.SD, function(x) mean(clean_vals(x))), .SDcols = sensor_names])
+    full    <- unlist(df[, lapply(.SD, function(x) mean(clean_vals(x))), .SDcols = sensor_names])
+    diff    <- full - first10
     # Derive sheet/year name
     year_tag <- sub("^SS_Y([0-9]{2})\\.txt$", "\\1", basename(f))
     # Map Y01=1995, Y02=1996, ..., Y20=2014


### PR DESCRIPTION
💡 **What:** Replaced the three `sapply(df[, ..sensor_names], ...)` calls inside `Updated_Seatek_Analysis.R` with data.table's native `unlist(df[..., lapply(.SD, ...), .SDcols = sensor_names])` operations.

🎯 **Why:** Using `sapply(df[, cols, with=FALSE], ...)` combined with row-based subsetting functions inside the loop (like `head(x, 10)` or `tail(x, 5)`) forces the creation of a subset `data.frame` first, then sequentially traverses each column and slices it. For wide datasets or long lists of years, this results in O(M * N) subsetting and unnecessary memory overhead. Moving the constraints to `data.table`'s `i` index (e.g., `df[1:min(10, .N), ...]`) pushes the row subsetting down to C-level in O(1) time before efficiently mapping the function across all target `.SDcols`.

📊 **Impact:** Reduces memory allocations during metric aggregation by applying the row subset once per loop iteration rather than once per sensor column per loop.

🔬 **Measurement:** Verify by running the analysis suite (`Updated_Seatek_Analysis.R`) across multiple years; functionally, output will be perfectly preserved while executing with less memory overhead.

---
*PR created automatically by Jules for task [10905502044314751940](https://jules.google.com/task/10905502044314751940) started by @abhimehro*