### PR TITLE
🎨 Palette: Fix progress bar garbling and improve CLI feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
+## 2025-05-06 - Progress Bar and Standard Output Garbling
+**Learning:** In interactive console applications, interleaving `cat` (standard output) statements within a loop that also updates a progress bar (e.g., `txtProgressBar` in R) causes the progress bar to become garbled and split across multiple lines, resulting in a confusing and messy UI.
+**Action:** When using a progress bar in a loop, ensure that all standard output or `cat` statements inside the loop are suppressed or redirected so the progress bar can render cleanly.
+
 ## 2025-05-06 - CLI Visual Feedback in Muffled Contexts
 **Learning:** In CLI applications (like R scripts) where message conditions are muffled (e.g., `message()` output via `invokeRestart("muffleMessage")`) or standard output is suppressed or redirected, long-running iterations can appear frozen to the user. This creates poor UX and uncertainty.
 **Action:** When designing or refactoring long-running loops (like file processing), always inject visual feedback that bypasses or operates alongside standard streams, such as `txtProgressBar` in R, to ensure the user receives consistent progress updates.

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -92,7 +92,7 @@ process_all_data <- function(data_dir) {
   on.exit({ close(pb); cat("\n✅ All files processed.\n") }, add = TRUE)
   i <- 0
   for (f in files) {
-    df <- read_sensor_data(f)
+    df <- read_sensor_data(f, verbose = FALSE)
     # Export raw data to Excel
     out_raw <- file.path(data_dir, paste0(
       tools::file_path_sans_ext(basename(f)), ".xlsx"
@@ -222,6 +222,7 @@ write_summary_sheets <- function(wb, summary_df, output_file,
   csv_all <- sub("\\.xlsx$", "_all.csv", output_file)
   data.table::fwrite(summary_df_all, csv_all, row.names = FALSE)
   message(sprintf("Comprehensive summary CSV written to %s", csv_all))
+  cat(sprintf("  📄 Saved: %s\n", basename(csv_all)))
 
   # --- Filtered summary (sufficient data only) ---
   min_count <- 5
@@ -235,6 +236,7 @@ write_summary_sheets <- function(wb, summary_df, output_file,
   csv_sufficient <- sub("\\.xlsx$", "_sufficient.csv", output_file)
   data.table::fwrite(summary_df_sufficient, csv_sufficient, row.names = FALSE)
   message(sprintf("Filtered summary CSV written to %s", csv_sufficient))
+  cat(sprintf("  📄 Saved: %s\n", basename(csv_sufficient)))
 
   # Continue with filtered summary for top sensors and highlighting
   summary_df <- summary_df_sufficient
@@ -253,9 +255,10 @@ write_summary_sheets <- function(wb, summary_df, output_file,
         "full_pct_nonmissing"
       )
     ]
-    data.table::fwrite(top_sensors,
-              sub("\\.xlsx$", "_top_sensors.csv", output_file),
-              row.names = FALSE)
+    csv_top <- sub("\\.xlsx$", "_top_sensors.csv", output_file)
+    data.table::fwrite(top_sensors, csv_top, row.names = FALSE)
+    cat(sprintf("  📄 Saved: %s\n", basename(csv_top)))
+
     addWorksheet(wb, "Summary_Top_Sensors")
     writeData(
       wb,
@@ -285,14 +288,17 @@ write_summary_sheets <- function(wb, summary_df, output_file,
   }
   saveWorkbook(wb, output_file, overwrite = TRUE)
   message(sprintf("Summary written to %s", output_file))
+  cat(sprintf("  📄 Saved: %s\n", basename(output_file)))
   # Also export summary as CSV for preview
   csv_out <- sub("\\.xlsx$", ".csv", output_file)
   data.table::fwrite(summary_df, csv_out, row.names = FALSE)
   message(sprintf("Summary CSV written to %s", csv_out))
+  cat(sprintf("  📄 Saved: %s\n", basename(csv_out)))
   # Export robust stats as CSV
   csv_robust <- sub("\\.xlsx$", "_robust.csv", output_file)
   data.table::fwrite(summary_df, csv_robust, row.names = FALSE)
   message(sprintf("Robust summary CSV written to %s", csv_robust))
+  cat(sprintf("  📄 Saved: %s\n", basename(csv_robust)))
 }
 
 # Write combined summary workbook
@@ -303,19 +309,25 @@ dump_summary_excel <- function(results, output_file, highlight_top_n = 5) {
   cat("\n📊 Generating yearly summary sheets...\n")
   message("Generating yearly summary sheets...")
   pb <- txtProgressBar(min = 0, max = length(results), style = 3)
-  on.exit({ close(pb); cat("\n✅ Summary workbook complete.\n") }, add = TRUE)
   i <- 0
   for (year in names(results)) {
     write_year_sheet(wb, year, results[[year]], header_style)
     i <- i + 1
     setTxtProgressBar(pb, i)
   }
+  close(pb)
+  cat("\n✅ Yearly sheets generated.\n")
 
+  cat("\n📈 Computing summary statistics...\n")
   # Compute summary statistics
   summary_df <- calculate_summary_stats(results)
+
+  cat("\n💾 Saving final workbook and CSV outputs...\n")
   # Write summary sheets and CSVs
   write_summary_sheets(wb, summary_df, output_file,
                        header_style, highlight_top_n)
+
+  cat("\n✅ Summary workbook complete.\n")
 }
 
 # Main execution block


### PR DESCRIPTION
This PR resolves an issue in the Seatek Analysis pipeline where the interactive `txtProgressBar` was being garbled and split across multiple lines due to standard output (`cat`) statements interleaving with its updates.

### What
- Suppressed verbose output from `read_sensor_data` during the main processing loop.
- Refactored `dump_summary_excel` to close the progress bar immediately after its loop, rather than waiting for function exit.
- Added structured `cat()` feedback for subsequent long-running steps (computing stats, saving files).
- Added direct feedback for file saves since `message()` logs are intercepted and muffled.

### Why
- **UX improvement**: The progress bar now renders smoothly on a single line.
- **Feedback visibility**: Users are no longer left with a frozen 100% progress bar while the pipeline computes and saves large Excel/CSV outputs. File saves are now explicitly printed to the console.

### Accessibility
- Ensures consistent and predictable console output for CLI users.

---
*PR created automatically by Jules for task [13527766292020573587](https://jules.google.com/task/13527766292020573587) started by @abhimehro*