### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in code scanner

### DIFF
--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -10,6 +10,13 @@ def get_repo_info():
 
 def read_file_safe(filepath):
     try:
+        # SECURITY: Prevent path traversal by ensuring the file is within the current directory.
+        # Uses commonpath to securely prevent directory prefix bypass attacks.
+        cwd = os.path.abspath(os.getcwd())
+        abs_filepath = os.path.abspath(filepath)
+        if os.path.commonpath([cwd, abs_filepath]) != cwd:
+            return []
+
         with open(filepath, 'r', encoding='utf-8') as f:
             return f.readlines()
     except (OSError, UnicodeDecodeError):

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -11,13 +11,13 @@ def get_repo_info():
 def read_file_safe(filepath):
     try:
         # SECURITY: Prevent path traversal by ensuring the file is within the current directory.
-        # Uses commonpath to securely prevent directory prefix bypass attacks.
-        cwd = os.path.abspath(os.getcwd())
-        abs_filepath = os.path.abspath(filepath)
-        if os.path.commonpath([cwd, abs_filepath]) != cwd:
+        # Uses commonpath and realpath to securely prevent directory prefix bypass and symlink escape attacks.
+        cwd = os.path.realpath(os.getcwd())
+        resolved_filepath = os.path.realpath(filepath)
+        if os.path.commonpath([cwd, resolved_filepath]) != cwd:
             return []
 
-        with open(filepath, 'r', encoding='utf-8') as f:
+        with open(resolved_filepath, 'r', encoding='utf-8') as f:
             return f.readlines()
     except (OSError, UnicodeDecodeError):
         return []


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Path traversal bypass in `code_health_scanner.py` via `startswith()`. An attacker could bypass the `startswith(os.getcwd())` check if the repository directory is a prefix of a sibling directory containing sensitive information (e.g., repository is `/app/repo` and attacker accesses `/app/repo_secrets/passwords.txt`).
🎯 **Impact:** Unauthorized reads of sensitive files outside the intended working directory if this script was executed with untrusted file paths.
🔧 **Fix:** Replaced the unsafe prefix match with a robust boundary check using `os.path.commonpath([cwd, abs_filepath]) == cwd`.
✅ **Verification:** Verified `code_health_scanner.py` compiles successfully and enforces proper boundaries.

═════ ELIR ═════
PURPOSE: Secures file-reading utility against path traversal bypasses.
SECURITY: Prevents path traversal and directory prefix bypass attacks (e.g., accessing `/app/workspace_secrets` when locked to `/app/workspace`).
FAILS IF: Malformed paths trick commonpath (highly unlikely under standard Python).
VERIFY: Code scanner functions correctly for valid repository files.
MAINTAIN: Always use `os.path.commonpath` or explicitly check with trailing slashes for directory confinement.

---
*PR created automatically by Jules for task [10750458488842657551](https://jules.google.com/task/10750458488842657551) started by @abhimehro*