### PR TITLE
🎨 Palette: Python CLI UX improvements for dataframe output

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-05-06 - Explicit Progress Bar Closure
 **Learning:** Depending on `on.exit()`-registered cleanup at function exit to close a progress bar delays the final newline output until the entire function returns. This can cause subsequent CLI output (like status messages or parallel processing logs) to become garbled or appended to the same line as the finished progress bar, significantly degrading the user experience.
 **Action:** Always explicitly call `close()` on the progress bar immediately after its loop finishes so that the bar is closed and its final newline is emitted before proceeding to other tasks in the same function. Retain the `on.exit()` cleanup for error handling, but do not rely on it for normal control flow.
+
+## 2025-05-06 - Preventing CLI Dataframe Console Spam
+**Learning:** In CLI tools that process and display dataframes, an unbound `.to_string()` call can result in massive console spam (dumping hundreds of rows) if the output is large. Furthermore, when the dataframe is empty, `.to_string()` prints ugly, unhelpful text (like "Empty DataFrame"). Both scenarios create a poor, cluttered user experience.
+**Action:** Always check `.empty` on dataframes before printing in CLI tools to provide a clear, friendly "No data found" message. Additionally, implement pagination or truncation (e.g., `head(20)`) for large outputs, adding a note that directs the user to an output file for the full details.

--- a/Series_27/Analysis/outlier_analysis_series27.py
+++ b/Series_27/Analysis/outlier_analysis_series27.py
@@ -9,7 +9,8 @@ import logging
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Series 27 Outlier Analysis and Correction"
+        description="Series 27 Outlier Analysis and Correction",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument(
         '-i', '--input', required=True,
@@ -232,7 +233,13 @@ def main():
     plot_outliers(outliers, args.method, args.threshold, args.output)
 
     # Display table
-    print(corr_df.to_string(index=False))
+    if corr_df.empty:
+        print("No outliers detected. No corrections applied.")
+    elif len(corr_df) > 20:
+        print(corr_df.head(20).to_string(index=False))
+        print(f"...\n[Output truncated. See '{corr_file}' for full details.]")
+    else:
+        print(corr_df.to_string(index=False))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
🎨 Palette: Python CLI UX improvements for dataframes

💡 What:
- Added `ArgumentDefaultsHelpFormatter` to `argparse` to show default arguments in `--help`.
- Updated final print statement in `main()` to gracefully handle empty DataFrames ("No outliers detected") and truncate large DataFrames (>20 rows) to prevent console spam.
- Added a new learning entry to `.jules/palette.md` documenting this pattern.

🎯 Why:
- Unbound `.to_string()` calls on pandas DataFrames cause severe terminal spam on large datasets, and print confusing "Empty DataFrame" messages when no data is found. These small tweaks make the CLI output significantly cleaner and more user-friendly.

📸 Before/After:
Before: `print(corr_df.to_string(index=False))` printed all rows or "Empty DataFrame".
After: Clear empty state message, or top 20 rows with a note directing users to the saved Excel file.

♿ Accessibility:
Cleaner terminal output reduces cognitive load and makes screen reader parsing of CLI output much easier, as it avoids reading hundreds of rows of raw tabular data.

---
*PR created automatically by Jules for task [14558178692454503386](https://jules.google.com/task/14558178692454503386) started by @abhimehro*