### PR TITLE
🎨 Palette: Add progress bar to sequential Excel export

### DIFF
--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -173,11 +173,24 @@ process_all_data <- function(data_dir) {
       for (out_file in out_files) {
         message(sprintf("Raw data written to %s", out_file))
       }
-    } else {
+    } else if (length(raw_export_tasks) > 0) {
+      pb_write <- txtProgressBar(min = 0, max = length(raw_export_tasks), style = 3)
+      on.exit({
+        if (!is.null(pb_write)) {
+          close(pb_write)
+          pb_write <- NULL
+        }
+      }, add = TRUE)
+      i <- 0
       for (task in raw_export_tasks) {
         out_file <- write_task(task)
-        message(sprintf("Raw data written to %s", out_file))
+        # Suppress message in the loop to prevent garbling the progress bar
+        # message(sprintf("Raw data written to %s", out_file))
+        i <- i + 1
+        setTxtProgressBar(pb_write, i)
       }
+      close(pb_write)
+      pb_write <- NULL
     }
   }
   cat("✅ Raw files written.\n")

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -175,22 +175,15 @@ process_all_data <- function(data_dir) {
       }
     } else if (length(raw_export_tasks) > 0) {
       pb_write <- txtProgressBar(min = 0, max = length(raw_export_tasks), style = 3)
-      on.exit({
-        if (!is.null(pb_write)) {
-          close(pb_write)
-          pb_write <- NULL
+      tryCatch({
+        for (i in seq_along(raw_export_tasks)) {
+          task <- raw_export_tasks[[i]]
+          out_file <- write_task(task)
+          # Suppress message in the loop to prevent garbling the progress bar
+          # message(sprintf("Raw data written to %s", out_file))
+          setTxtProgressBar(pb_write, i)
         }
-      }, add = TRUE)
-      i <- 0
-      for (task in raw_export_tasks) {
-        out_file <- write_task(task)
-        # Suppress message in the loop to prevent garbling the progress bar
-        # message(sprintf("Raw data written to %s", out_file))
-        i <- i + 1
-        setTxtProgressBar(pb_write, i)
-      }
-      close(pb_write)
-      pb_write <- NULL
+      }, finally = close(pb_write))
     }
   }
   cat("✅ Raw files written.\n")


### PR DESCRIPTION
💡 What: Added a `txtProgressBar` to the fallback sequential execution path for writing raw Excel files in `Updated_Seatek_Analysis.R`. Muffled `message()` calls inside the loop were commented out to prevent garbling the bar, and a length check was added to prevent errors on empty lists.

🎯 Why: In CLI applications, long-running loops with muffled output cause the terminal to appear frozen, which is a poor user experience. Adding visual feedback that bypasses standard streams keeps the user informed of progress.

♿ Accessibility: N/A (CLI specific UX improvement to prevent freezing)

---
*PR created automatically by Jules for task [18204193689607914322](https://jules.google.com/task/18204193689607914322) started by @abhimehro*