### PR TITLE
🛡️ Sentinel: [MEDIUM] Remove stack trace from error response

### DIFF
--- a/Series_27/Analysis/outlier_analysis_series27.py
+++ b/Series_27/Analysis/outlier_analysis_series27.py
@@ -161,14 +161,14 @@ def apply_corrections(input_path, output_dir, outliers_df):
                     # Write once per sheet
                     df_raw.to_excel(out_file, sheet_name=sheet, index=False)
         except (FileNotFoundError, PermissionError, OSError) as e:
+            # SECURITY: Do not leak stack traces in logs to prevent information disclosure
             logging.error(
-                f"Could not open file '{input_path}': {e}",
-                exc_info=True,
+                f"Could not open file '{input_path}': {e}"
             )
         except (ValueError, KeyError) as e:
+            # SECURITY: Do not leak stack traces in logs to prevent information disclosure
             logging.error(
-                f"Error reading or processing Excel data from '{input_path}': {e}",
-                exc_info=True,
+                f"Error reading or processing Excel data from '{input_path}': {e}"
             )
 
     if corrections_dfs:


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Uncaught stack trace logging via `exc_info=True` in error handlers within `Series_27/Analysis/outlier_analysis_series27.py`.
🎯 **Impact:** Exposes internal implementation details, such as absolute paths, Python environment locations, and application structure via log files, leading to potential information disclosure.
🔧 **Fix:** Removed `exc_info=True` from standard error logs to ensure application fails securely while still reporting the error string explicitly. Added a corresponding security note.
✅ **Verification:** Ran `python -m py_compile` to ensure valid Python syntax, checked script output for valid handling.

---
*PR created automatically by Jules for task [10679236816939182644](https://jules.google.com/task/10679236816939182644) started by @abhimehro*