### PR TITLE
⚡ Bolt: [Performance] Aggregate results as data.table to prevent serial I/O overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,7 @@
 ## 2025-05-06 - Avoid Redundant Memory Allocations in R Data validations
 **Learning:** Using `if (all(!is.na(as.numeric(x))))` in combination with a second `as.numeric(x)` call inside the conditional block is inefficient for large vectors. This pattern creates four intermediate vectors (two from the numeric casts, one from `is.na`, and one from `!`) and requires multiple full-column traversals.
 **Action:** Extract the cast to a variable `num_ts <- suppressWarnings(as.numeric(x))` and use `!anyNA(num_ts)` which short-circuits in C without creating intermediate logical vectors, and reuse `num_ts` to avoid a second parse.
+
+## 2025-05-06 - Native data.table aggregation in R Loops
+**Learning:** Storing list results as `data.frame` objects with `row.names` inside a loop forces subsequent aggregations to convert back using expensive `lapply` loops (e.g. `lapply(results, as.data.table)`).
+**Action:** Store the results natively as `data.table` objects within the loop, including an explicit identifier column (e.g. `Sensor = sensor_names`), to allow for O(1) assignments in `write_year_sheet` (using `rowNames = FALSE`) and immediate concatenation via `rbindlist(results)`.

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -131,13 +131,14 @@ process_all_data <- function(data_dir) {
     } else {
       basename(f)
     }
-    results[[i + 1]] <- data.frame(
+    # ⚡ Bolt: Store results natively as data.table with explicit Sensor ID
+    # Avoids data.frame/row.names overhead and enables fast rbindlist downstream
+    results[[i + 1]] <- data.table(
+      Sensor = sensor_names,
       first10 = first10,
       last5 = last5,
       full = full,
-      within_diff = diff,
-      row.names = sensor_names,
-      check.names = FALSE
+      within_diff = diff
     )
     sheet_names[i + 1] <- sheet_name
     i <- i + 1
@@ -193,17 +194,18 @@ process_all_data <- function(data_dir) {
 # Write a single year's sheet to the workbook
 write_year_sheet <- function(wb, year, data, header_style) {
   addWorksheet(wb, year)
-  df <- as.data.frame(data)
-  writeData(wb, sheet = year, x = df, rowNames = TRUE,
+  # ⚡ Bolt: No as.data.frame() conversion needed, use data.table natively
+  writeData(wb, sheet = year, x = data, rowNames = FALSE,
             headerStyle = header_style)
   freezePane(wb, sheet = year, firstRow = TRUE)
   # Optional: highlight largest within_diff in each year
-  if ("within_diff" %in% colnames(df)) {
-    max_idx <- which.max(abs(df$within_diff))
+  if ("within_diff" %in% colnames(data)) {
+    max_idx <- which.max(abs(data$within_diff))
     highlight_style_yearly <- createStyle(bgFill = "#FFD700")
+    # ⚡ Bolt: Remove '+ 1' from cols offset since Sensor is a standard column now
     addStyle(wb, sheet = year, style = highlight_style_yearly,
              rows = max_idx + 1,
-             cols = which(colnames(df) == "within_diff") + 1,
+             cols = which(colnames(data) == "within_diff"),
              gridExpand = TRUE, stack = TRUE)
   }
 }
@@ -211,11 +213,8 @@ write_year_sheet <- function(wb, year, data, header_style) {
 # Compute summary statistics across all years
 calculate_summary_stats <- function(results) {
   # Add summary sheet with overall stats
-  # Convert results list to data.table, preserving row names (Sensor) and order (Year)
-  dt_list <- lapply(results, function(x) {
-    as.data.table(x, keep.rownames = "Sensor")
-  })
-  all_stats_dt <- rbindlist(dt_list, idcol = "Year")
+  # ⚡ Bolt: No lapply conversion required. results list natively contains data.tables
+  all_stats_dt <- rbindlist(results, idcol = "Year")
 
   # Identify metric columns (numeric columns excluding ID columns)
   metrics <- setdiff(names(all_stats_dt), c("Sensor", "Year"))


### PR DESCRIPTION
💡 **What:** 
Stores the aggregated output for each sensor file natively as a `data.table` including the explicit "Sensor" column within the processing loop instead of a `data.frame` with `row.names`. 

🎯 **Why:** 
Previously, the `results` list populated the loop natively as `data.frame`s relying on `row.names` to track IDs. 
1. `write_year_sheet` then had to cast this back to an explicit `data.frame`.
2. `calculate_summary_stats` had to invoke an expensive `lapply` loop to cast every item back to `data.table(keep.rownames = "Sensor")` in order to use `rbindlist()`.
By injecting the data natively in the required state, we prevent multiple O(N) iterations.

📊 **Impact:** 
Expected to reduce CPU cycles and memory allocations when casting intermediate matrices spanning hundreds of iterations, improving overall `process_all_data` and downstream aggregation speed.

🔬 **Measurement:** 
Verify the output formatting has not changed by confirming the ID column properly shifts using standard `writeData(..., rowNames = FALSE)` checks against previous exports, and bench testing `process_all_data` run durations across massive input datasets.

---
*PR created automatically by Jules for task [13073221951967298735](https://jules.google.com/task/13073221951967298735) started by @abhimehro*