### PR TITLE
🎨 Palette: Add empty iterable check to progress bar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-05-06 - Preventing CLI Dataframe Console Spam
 **Learning:** In CLI tools that process and display dataframes, an unbound `.to_string()` call can result in massive console spam (dumping hundreds of rows) if the output is large. Furthermore, when the dataframe is empty, `.to_string()` prints ugly, unhelpful text (like "Empty DataFrame"). Both scenarios create a poor, cluttered user experience.
 **Action:** Always check `.empty` on dataframes before printing in CLI tools to provide a clear, friendly "No data found" message. Additionally, implement pagination or truncation (e.g., `head(20)`) for large outputs, adding a note that directs the user to an output file for the full details.
+
+## 2025-05-06 - Empty Iterables and Progress Bars
+**Learning:** In R, initializing `txtProgressBar` with a length-zero vector or empty list throws a fatal error (`must have 'max' > 'min'`), which crashes the CLI application.
+**Action:** When creating a progress bar for dynamic iterables, always wrap the initialization and loop inside a length check (e.g., `if (length(items) > 0)`) to ensure the application fails gracefully or bypasses the empty state.

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -365,14 +365,16 @@ dump_summary_excel <- function(results, output_file, highlight_top_n = 5) {
   # Write each year's sheet
   cat("\n📊 Generating yearly summary sheets...\n")
   message("Generating yearly summary sheets...")
-  pb <- txtProgressBar(min = 0, max = length(results), style = 3)
-  i <- 0
-  for (year in names(results)) {
-    write_year_sheet(wb, year, results[[year]], header_style)
-    i <- i + 1
-    setTxtProgressBar(pb, i)
+  if (length(results) > 0) {
+    pb <- txtProgressBar(min = 0, max = length(results), style = 3)
+    i <- 0
+    for (year in names(results)) {
+      write_year_sheet(wb, year, results[[year]], header_style)
+      i <- i + 1
+      setTxtProgressBar(pb, i)
+    }
+    close(pb)
   }
-  close(pb)
   cat("\n✅ Yearly sheets generated.\n")
 
   cat("\n📈 Computing summary statistics...\n")


### PR DESCRIPTION
💡 What: Added an `if (length(results) > 0)` check around the `txtProgressBar` loop in `Updated_Seatek_Analysis.R`.
🎯 Why: If the results list is completely empty, `txtProgressBar` throws a fatal error because the `max` value must be greater than the `min` value. This check ensures the CLI app fails gracefully or simply skips the empty progress bar, preventing a confusing stack trace for the user.
♿ Accessibility: N/A - Implemented a UX/stability fix for CLI visual feedback.

---
*PR created automatically by Jules for task [13949250957600367429](https://jules.google.com/task/13949250957600367429) started by @abhimehro*