### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent log file leakage by ignoring renv_restore.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 venv/
 test_out_*.xlsx
+renv_restore.log


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Ignore `renv_restore.log`

🚨 Severity: MEDIUM
💡 Vulnerability: Generated local log files (like `renv_restore.log` generated by `setup.sh`) were not explicitly excluded from version control in `.gitignore`.
🎯 Impact: This could lead to inadvertent codebase pollution. Furthermore, log files can occasionally leak sensitive local paths, environment details, or package dependency resolution history to the repository.
🔧 Fix: Appended `renv_restore.log` to `.gitignore`.
✅ Verification: Ran `cat .gitignore` and verified the entry is present.

═════ ELIR ═════
PURPOSE: Exclude `renv_restore.log` from version control.
SECURITY: Prevents accidental commit of local environment information and dependency paths that could aid reconnaissance.
FAILS IF: The log file is generated with a different name.
VERIFY: `.gitignore` contains `renv_restore.log`.
MAINTAIN: Keep `.gitignore` updated when introducing new temporary files or local build scripts.

---
*PR created automatically by Jules for task [12936682893618069833](https://jules.google.com/task/12936682893618069833) started by @abhimehro*