### PR TITLE
🎨 Palette: Add empty list check for txtProgressBar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-05-06 - Preventing CLI Dataframe Console Spam
 **Learning:** In CLI tools that process and display dataframes, an unbound `.to_string()` call can result in massive console spam (dumping hundreds of rows) if the output is large. Furthermore, when the dataframe is empty, `.to_string()` prints ugly, unhelpful text (like "Empty DataFrame"). Both scenarios create a poor, cluttered user experience.
 **Action:** Always check `.empty` on dataframes before printing in CLI tools to provide a clear, friendly "No data found" message. Additionally, implement pagination or truncation (e.g., `head(20)`) for large outputs, adding a note that directs the user to an output file for the full details.
+
+## 2025-05-06 - Empty List Crash with `txtProgressBar`
+**Learning:** In R, `txtProgressBar` requires `max > min`. When initializing a progress bar for a list or vector that might be empty, initializing it directly will result in a fatal error (`must have 'max' > 'min'`), crashing the script. This creates a terrible user experience if an unexpected data edge case occurs.
+**Action:** Always wrap progress bar initialization and its corresponding loop in a length check (e.g., `if (length(items) > 0)`) to gracefully handle empty inputs without breaking the CLI.

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -365,14 +365,16 @@ dump_summary_excel <- function(results, output_file, highlight_top_n = 5) {
   # Write each year's sheet
   cat("\n📊 Generating yearly summary sheets...\n")
   message("Generating yearly summary sheets...")
-  pb <- txtProgressBar(min = 0, max = length(results), style = 3)
-  i <- 0
-  for (year in names(results)) {
-    write_year_sheet(wb, year, results[[year]], header_style)
-    i <- i + 1
-    setTxtProgressBar(pb, i)
+  if (length(results) > 0) {
+    pb <- txtProgressBar(min = 0, max = length(results), style = 3)
+    i <- 0
+    for (year in names(results)) {
+      write_year_sheet(wb, year, results[[year]], header_style)
+      i <- i + 1
+      setTxtProgressBar(pb, i)
+    }
+    close(pb)
   }
-  close(pb)
   cat("\n✅ Yearly sheets generated.\n")
 
   cat("\n📈 Computing summary statistics...\n")


### PR DESCRIPTION
💡 What: Wrapped the `txtProgressBar` initialization and loop inside a `if (length(results) > 0)` check in `Updated_Seatek_Analysis.R`. Added a corresponding learning to `.jules/palette.md`.
🎯 Why: In R, `txtProgressBar` requires `max > min`. Initializing it for an empty list causes a fatal error (`must have 'max' > 'min'`), which completely breaks the script and CLI execution if an edge case produces empty data.
📸 Before/After: Visual CLI change (prevents an ugly R traceback dump and script failure when lists are empty).
♿ Accessibility: Prevents the CLI from crashing ungracefully and ensures the script finishes cleanly even when no data is processed. Improved robustness of the CLI output experience.

---
*PR created automatically by Jules for task [6398039857686685690](https://jules.google.com/task/6398039857686685690) started by @abhimehro*