### PR TITLE
🎨 Palette: Add robust on.exit cleanup to txtProgressBar

### DIFF
--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -370,6 +370,13 @@ dump_summary_excel <- function(results, output_file, highlight_top_n = 5) {
   message("Generating yearly summary sheets...")
   if (length(results) > 0) {
     pb <- txtProgressBar(min = 0, max = length(results), style = 3)
+    # 🎨 Palette: Add robust cleanup to prevent garbled console on error
+    on.exit({
+      if (!is.null(pb)) {
+        close(pb)
+        pb <- NULL
+      }
+    }, add = TRUE)
     i <- 0
     for (year in names(results)) {
       write_year_sheet(wb, year, results[[year]], header_style)


### PR DESCRIPTION
💡 **What:** Added an `on.exit()` cleanup handler for the `txtProgressBar` used during the final summary Excel sheet generation in `Updated_Seatek_Analysis.R`.
🎯 **Why:** If `write_year_sheet` or the loop fails/exits early, the unclosed progress bar delays the final newline output and garbles subsequent standard output/messages, significantly degrading the CLI UX. By adding a robust `on.exit` handler that checks and securely closes `pb`, we ensure the console is cleanly released under all execution paths.
📸 **Before/After:** No visual changes since it's a backend R script.
♿ **Accessibility/UX:** Improves terminal consistency and feedback clarity during errors by preventing "frozen" or broken console states.

---
*PR created automatically by Jules for task [17624390754923277268](https://jules.google.com/task/17624390754923277268) started by @abhimehro*