### PR TITLE
🎨 Palette: Prevent empty plot generation and add clean CLI error messages

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,11 @@
 ## 2025-05-06 - Empty List Crash with `txtProgressBar`
 **Learning:** In R, `txtProgressBar` requires `max > min`. When initializing a progress bar for a list or vector that might be empty, initializing it directly will result in a fatal error (`must have 'max' > 'min'`), crashing the script. This creates a terrible user experience if an unexpected data edge case occurs.
 **Action:** Always wrap progress bar initialization and its corresponding loop in a length check (e.g., `if (length(items) > 0)`) to gracefully handle empty inputs without breaking the CLI.
+
+## 2025-05-06 - Preventing Empty Visual Artifacts
+**Learning:** Generating empty visual artifacts (like a blank `.png` plot) when a condition is unmet (e.g., zero outliers detected) causes user confusion and clutters output directories.
+**Action:** Always verify if the dataset is empty before generating a visual artifact, and provide a clear, helpful console message indicating why the step was skipped.
+
+## 2025-05-06 - CLI Input Validation Error UX
+**Learning:** Allowing standard library exceptions (like FileNotFoundError) to bubble up directly to the user creates a poor CLI experience filled with scary stack traces.
+**Action:** Explicitly validate user-provided file paths early and provide a clean, human-readable error message.

--- a/Series_27/Analysis/outlier_analysis_series27.py
+++ b/Series_27/Analysis/outlier_analysis_series27.py
@@ -212,12 +212,12 @@ def main():
     logging.basicConfig(level=logging.INFO,
                         format='%(levelname)s: %(message)s')
 
-    if not os.path.exists(args.input):
+    logging.info("Loading year-to-year differences")
+    try:
+        diff_df = pd.read_excel(args.input, sheet_name=args.sheet_summary)
+    except FileNotFoundError:
         logging.error(f"Input file not found: '{args.input}'")
         return
-
-    logging.info("Loading year-to-year differences")
-    diff_df = pd.read_excel(args.input, sheet_name=args.sheet_summary)
     long_df = diff_df.melt(
         id_vars='Year_Pair', var_name='Sensor', value_name='Difference'
     )

--- a/Series_27/Analysis/outlier_analysis_series27.py
+++ b/Series_27/Analysis/outlier_analysis_series27.py
@@ -179,6 +179,10 @@ def apply_corrections(input_path, output_dir, outliers_df):
 
 def plot_outliers(outliers, method, threshold, output_dir):
     """Generates and saves the scatter plot for outliers."""
+    if outliers.empty:
+        logging.info("No outliers to plot. Skipping plot generation.")
+        return
+
     plt.figure(figsize=(12, 6))
     plt.scatter(range(len(outliers)), outliers['Difference'], s=50)
     plt.axhline(0, color='gray')
@@ -207,6 +211,10 @@ def main():
     os.makedirs(args.output, exist_ok=True)
     logging.basicConfig(level=logging.INFO,
                         format='%(levelname)s: %(message)s')
+
+    if not os.path.exists(args.input):
+        logging.error(f"Input file not found: '{args.input}'")
+        return
 
     logging.info("Loading year-to-year differences")
     diff_df = pd.read_excel(args.input, sheet_name=args.sheet_summary)


### PR DESCRIPTION
🎨 Palette: Prevent empty plot generation and add clean CLI error messages

💡 What:
1. Added an early exit to `plot_outliers` in `outlier_analysis_series27.py` to prevent generating a blank `.png` file if no outliers are detected.
2. Added an explicit `os.path.exists()` check in `main()` before calling `pd.read_excel`, logging a clean error message instead of throwing a `FileNotFoundError` traceback.
3. Documented these UX practices in `.jules/palette.md`.

🎯 Why:
- **Preventing Empty Visual Artifacts:** Generating empty visual artifacts when a condition is unmet causes user confusion and clutters output directories.
- **CLI Input Validation:** Allowing standard library exceptions to bubble up creates a terrifying CLI experience. Explicitly validating file paths early provides a clean, human-readable error.

♿ Accessibility:
N/A (Backend CLI tool)

📸 Before/After:
**Before (Missing File):**
```
Traceback (most recent call last):
  File "outlier_analysis_series27.py", line ...
    ...
FileNotFoundError: [Errno 2] No such file or directory: 'nonexistent.xlsx'
```
**After (Missing File):**
```
ERROR: Input file not found: 'nonexistent.xlsx'
```

---
*PR created automatically by Jules for task [4137199033221794768](https://jules.google.com/task/4137199033221794768) started by @abhimehro*