### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,8 @@
 name: PR Checks
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/abhimehro/Seatek_Analysis/security/code-scanning/6](https://github.com/abhimehro/Seatek_Analysis/security/code-scanning/6)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions in the workflow to the minimum needed. This workflow only needs to read the repository contents to run checks, so `contents: read` at the workflow root is sufficient and will apply to all jobs that don’t override it.

Concretely, in `.github/workflows/pr.yml`, add a `permissions:` block near the top-level (alongside `name:` and `on:`) with `contents: read`. No other permissions are required, and no existing steps need modification. The change is limited to this single YAML file and introduces no new imports or dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
