### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,5 +1,8 @@
 name: PR Validation
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/abhimehro/Seatek_Analysis/security/code-scanning/10](https://github.com/abhimehro/Seatek_Analysis/security/code-scanning/10)

In general, the fix is to explicitly declare a `permissions` block for the workflow (or for the specific job) that grants only the minimal required scopes for `GITHUB_TOKEN`. For this PR validation workflow, the steps only need to read repository contents to check out code; they do not need to write to the repo or modify issues/PRs.

The best targeted fix is to add a `permissions` block at the workflow root level (top-level, alongside `name` and `on`) that sets `contents: read`. This will apply to all jobs in the workflow, including `validate`, and ensures the `GITHUB_TOKEN` has read-only access to repository contents. No existing steps need to be changed, and no new functionality is introduced; this only tightens security. Concretely, in `.github/workflows/pr-validation.yml`, add:

```yaml
permissions:
  contents: read
```

between the `name: PR Validation` and the `on:` block. No imports or additional methods are required, as this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
