### PR TITLE
⚡ Bolt: Avoid full DataFrame copies when dropping single columns

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@
 ## 2025-05-06 - Vectorize Pandas Column Subtraction
 **Learning:** Iterating through columns in a Python loop (e.g. `for col, val in values.items(): df[col] = df[col] - val`) incurs Python-level interpreter overhead, especially when updating many columns.
 **Action:** Vectorizing column-wise subtraction in Pandas using `df[cols] = df[cols].sub(values_series, axis=1)` is significantly more efficient than updating columns individually within a Python `for` loop, as it leverages optimized C-level operations and broadcasting.
+
+## 2025-05-06 - Avoid Full DataFrame Copies for Single Column Drops
+**Learning:** In Pandas, dropping a single column using `df = df.iloc[:, :-1].copy()` forces a complete allocation and copy of the DataFrame. When processing many sheets or large datasets inside a loop, this O(N*M) operation severely degrades performance and memory efficiency.
+**Action:** When dropping a single column, prefer in-place operations like `del df[col_name]` or `df.drop(columns=[col_name], inplace=True)` to avoid unnecessary full DataFrame memory allocations.

--- a/Series_27/Analysis/outlier_analysis_series27.py
+++ b/Series_27/Analysis/outlier_analysis_series27.py
@@ -156,7 +156,8 @@ def apply_corrections(input_path, output_dir, outliers_df):
                     # Drop the last column if its name contains 'time' (case-insensitive)
                     last_col = df_raw.columns[-1]
                     if "time" in last_col.lower():
-                        df_raw = df_raw.iloc[:, :-1].copy()
+                        # ⚡ Bolt: Use 'del' instead of '.iloc[:, :-1].copy()' to avoid O(N*M) full DataFrame memory allocation
+                        del df_raw[last_col]
 
                     next_year = group.iloc[0]["next_year"]
 


### PR DESCRIPTION
💡 **What**: Replaced `df_raw = df_raw.iloc[:, :-1].copy()` with an in-place `del df_raw[last_col]` when dropping the final time column in the outlier analysis script.
🎯 **Why**: Using `.iloc` with `.copy()` forces Pandas to allocate an entirely new block of memory and copy the entire DataFrame, which creates significant overhead when iteratively processing multiple large Excel sheets inside a loop.
📊 **Impact**: Reduces peak memory allocation per loop iteration and transforms an O(N*M) full-table copy operation into a lightweight O(1) column reference deletion.
🔬 **Measurement**: Verify by benchmarking memory usage and execution time of `apply_corrections` across multiple large Excel sheets containing a 'time' column.

---
*PR created automatically by Jules for task [7187604623620491369](https://jules.google.com/task/7187604623620491369) started by @abhimehro*