### PR TITLE
⚡ Bolt: Optimize file extension check using tuple with endswith

### DIFF
--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -150,7 +150,8 @@ def discover_hotspots(limit: int = 5) -> list[tuple[str, int]]:
     for current_dir, dirs, files in os.walk(ROOT, topdown=True):
         dirs[:] = [d for d in dirs if d not in IGNORED_DIRS]
         for file in files:
-            if not (file.endswith(".py") or file.endswith(".sh")):
+            # ⚡ Bolt: Use tuple with .endswith() for faster C-level evaluation
+            if not file.endswith((".py", ".sh")):
                 continue
             path = ROOT / os.path.relpath(os.path.join(current_dir, file), ROOT)
             try:


### PR DESCRIPTION
💡 What: Replaced an `or` chain with a tuple argument for `.endswith()`.
🎯 Why: In `discover_hotspots` which traverses the entire repository, evaluating `endswith` at the C-level with a tuple avoids the overhead of evaluating `.endswith()` twice along with a Python `or` operator.
📊 Impact: Micro-optimization for Python performance when scanning large repositories.
🔬 Measurement: The change was verified through compilation (`python3 -m py_compile`) and isolated testing.

---
*PR created automatically by Jules for task [15198598887192713825](https://jules.google.com/task/15198598887192713825) started by @abhimehro*