### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix data leakage in generic exception handlers

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -402,6 +402,6 @@ def append_publication_result(
         body += f"\n## Published issue\n- {issue_url}\n"
         return body, issue_url, None
     except Exception as exc:  # pragma: no cover - runtime integration
-        logging.error("Error publishing issue/PR", exc_info=True)
+        logging.error(f"Error publishing issue/PR: {type(exc).__name__}")
         body += f"\n## Publishing failure\n- {type(exc).__name__}\n"
         return body, "", type(exc).__name__

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -62,3 +62,15 @@
 **Vulnerability:** A code scanning script used `os.path.getsize(filepath)` to check if a file was under a maximum size limit before opening and reading it with `open()` and `f.readlines()`.
 **Learning:** Checking a file's size and then opening it creates a race condition known as Time-of-Check to Time-of-Use (TOCTOU). An attacker could swap the file for a much larger one between the size check and the read operation, leading to a Denial of Service via memory exhaustion.
 **Prevention:** Avoid separate check and use steps when dealing with files. Instead, open the file and read up to `MAX_FILE_SIZE + 1` bytes. If the length of the read content exceeds `MAX_FILE_SIZE`, you know the file is too large and can reject it safely without TOCTOU risks.
+
+## 2025-08-11 - CLI Option Injection via printf format strings
+
+**Vulnerability:** When using `printf` to output environment variables that contain untrusted text (like user-supplied GitHub Issue titles or AI-generated output), the content can be mistakenly parsed as an option flag if the string starts with a hyphen (e.g. `printf "%s\n" "$VAR"`).
+**Learning:** `printf` commands that output variable content can be vulnerable to option injection even when properly quoted, which could cause build failures or unintended behavior in shell scripts.
+**Prevention:** Always use the `--` separator with `printf` when formatting variables to ensure everything that follows is treated as the format string or positional arguments, preventing option injection (e.g., `printf -- "%s\n" "$VAR" > output.txt`).
+
+## 2025-08-11 - Information Leakage via exc_info in Generic Exception Handlers
+
+**Vulnerability:** Using `exc_info=True` in generic exception handlers (`except Exception as exc:`) logs the full stack trace and exception details, which can unintentionally leak sensitive internal application paths, state, environment variables, or database queries depending on the underlying error.
+**Learning:** While `exc_info=True` aids debugging, its use in high-level generic exception blocks constitutes an information disclosure risk, particularly when logs are accessible to less privileged users or centralized logging systems.
+**Prevention:** Avoid `exc_info=True` in broad exception handlers. Fail securely by logging a generic user-facing message, and include only the exception type (e.g., `type(exc).__name__`) to preserve debuggability without exposing sensitive string contents or stack traces.


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix data leakage in generic exception handlers

🚨 Severity: MEDIUM
💡 Vulnerability: Information Leakage via exc_info in Generic Exception Handlers
🎯 Impact: Using `exc_info=True` in broad exception blocks causes the full stack trace and exception details to be logged, potentially exposing sensitive internal application state, database queries, and internal paths to logs.
🔧 Fix: Removed `exc_info=True` from the generic exception handler in `repository_automation_common.py` and replaced it with a secure generic message containing only the exception type (e.g., `type(exc).__name__`). Updated `.jules/sentinel.md` with the critical learning.
✅ Verification: Ran python syntax checks and code review. Verified `exc_info` is no longer used in `append_publication_result`.

---
*PR created automatically by Jules for task [2518861507525837529](https://jules.google.com/task/2518861507525837529) started by @abhimehro*