### PR TITLE
⚡ Bolt: [performance improvement] Remove unused tidyverse dependencies

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -6,3 +6,6 @@
 ## 2025-05-06 - Optimize string processing in parsing loops
 **Learning:** Calling object-allocating methods like `.strip()`, `.lstrip()`, or `.lower()` on every line in a large file scanning loop introduces significant memory and CPU overhead.
 **Action:** Use a fast-fail substring check (`if "pattern" in line:`) before executing the more expensive operations. This short-circuits the condition for lines that don't match, often yielding ~10x faster execution for non-matching lines. Remember to combine conditions with `and` on the same line to avoid increasing nested code complexity.
+## 2025-05-06 - Remove unused large dependencies
+**Learning:** In R, loading large packages like `dplyr` and `tidyr` takes significant time and memory. If a script exclusively relies on `data.table` and `openxlsx`, importing unused packages is an anti-pattern that slows down execution.
+**Action:** Audit script dependencies and remove package loads for libraries whose functions are not actually used in the code.

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -10,7 +10,9 @@
 # and generates a combined summary workbook.
 
 # Load required packages (install if missing)
-required_packages <- c("data.table", "openxlsx", "dplyr", "tidyr")
+# ⚡ Bolt: Removed 'dplyr' and 'tidyr' dependencies to reduce memory overhead
+# and load times, as the script exclusively uses 'data.table' and 'openxlsx'.
+required_packages <- c("data.table", "openxlsx")
 for (pkg in required_packages) {
   if (!requireNamespace(pkg, quietly = TRUE)) {
     # Use HTTPS to prevent MITM attacks
@@ -20,8 +22,6 @@ for (pkg in required_packages) {
 
 library(data.table)
 library(openxlsx)
-library(dplyr)
-library(tidyr)
 
 # Log all warnings, errors, and messages to a file for diagnostics
 log_file <- file.path(getwd(), "processing_warnings.log")


### PR DESCRIPTION
💡 What: Removed `dplyr` and `tidyr` dependencies from `Updated_Seatek_Analysis.R`.
🎯 Why: The script was exclusively using `data.table` and `openxlsx`, making the importing of `dplyr` and `tidyr` unnecessary. Loading large packages like those in the tidyverse can take significant time and use extra memory.
📊 Impact: Faster script execution and reduced memory overhead, reducing the footprint of the analysis tool.
🔬 Measurement: Verify script functionality by running the processing logic or the tests; observing reduced memory usage and faster startup times compared to versions with the full tidyverse imports.

---
*PR created automatically by Jules for task [13173582709210216599](https://jules.google.com/task/13173582709210216599) started by @abhimehro*