### PR TITLE
⚡ Bolt: Remove unused dplyr and tidyr from Updated_Seatek_Analysis.R

### DIFF
--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -9,8 +9,11 @@
 # computes summary metrics (first 10, last 5, full, within_diff),
 # and generates a combined summary workbook.
 
+# ⚡ Bolt: Removed unused dependencies dplyr and tidyr to reduce memory overhead and script load time.
+# Performance metric: Removes the need to allocate memory for the large dplyr and tidyr namespaces.
+
 # Load required packages (install if missing)
-required_packages <- c("data.table", "openxlsx", "dplyr", "tidyr")
+required_packages <- c("data.table", "openxlsx")
 for (pkg in required_packages) {
   if (!requireNamespace(pkg, quietly = TRUE)) {
     # Use HTTPS to prevent MITM attacks
@@ -20,8 +23,6 @@ for (pkg in required_packages) {
 
 library(data.table)
 library(openxlsx)
-library(dplyr)
-library(tidyr)
 
 # Log all warnings, errors, and messages to a file for diagnostics
 log_file <- file.path(getwd(), "processing_warnings.log")


### PR DESCRIPTION
💡 What: Removed `dplyr` and `tidyr` from the required packages and `library()` calls in `Updated_Seatek_Analysis.R`.
🎯 Why: These packages are large, complex, and not actually utilized within the script. Loading them unnecessarily adds overhead to the application's memory footprint and increases the initial startup time of the script.
📊 Impact: Speeds up script startup time and reduces memory consumption by avoiding the allocation of unused, large package namespaces.
🔬 Measurement: Verify by executing the R script and monitoring memory usage and load time, comparing before and after values (e.g. using `time` to measure run duration).

---
*PR created automatically by Jules for task [1193245875503408891](https://jules.google.com/task/1193245875503408891) started by @abhimehro*