### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent GH_TOKEN leakage to third-party tools

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -61,7 +61,10 @@ def run_process(
     input_text: str | None = None,
     timeout: int = 300,
     check: bool = False,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
+    if env is None:
+        env = command_env()
     return subprocess.run(
         command,
         cwd=ROOT,
@@ -70,13 +73,16 @@ def run_process(
         text=True,
         input=input_text,
         timeout=timeout,
-        env=command_env(),
+        env=env,
     )
 
 
 def run_shell_command(command: str, timeout: int = 1800) -> dict[str, Any]:
     # Commands originate from repository-controlled configuration, not user input.
-    proc = run_process([BASH_BIN, "-lc", command], timeout=timeout)
+    # SECURITY: Strip GH_TOKEN to prevent third-party tools (pytest, bandit) from exfiltrating it.
+    safe_env = command_env()
+    safe_env.pop("GH_TOKEN", None)
+    proc = run_process([BASH_BIN, "-lc", command], timeout=timeout, env=safe_env)
     return {
         "command": command,
         "exit_code": proc.returncode,

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -74,3 +74,8 @@
 **Vulnerability:** Using `exc_info=True` in generic exception handlers (`except Exception as exc:`) logs the full stack trace and exception details, which can unintentionally leak sensitive internal application paths, state, environment variables, or database queries depending on the underlying error.
 **Learning:** While `exc_info=True` aids debugging, its use in high-level generic exception blocks constitutes an information disclosure risk, particularly when logs are accessible to less privileged users or centralized logging systems.
 **Prevention:** Avoid `exc_info=True` in broad exception handlers. Fail securely by logging a generic user-facing message, and include only the exception type (e.g., `type(exc).__name__`) to preserve debuggability without exposing sensitive string contents or stack traces.
+
+## 2026-04-19 - [CRITICAL] Prevent GH_TOKEN Leakage to Third-Party Tools
+**Vulnerability:** The `GH_TOKEN` environment variable was being passed to all shell commands executed via `run_shell_command`, exposing it to potentially compromised third-party tools like `pytest` or `pre-commit`.
+**Learning:** CI/CD runners often have elevated privileges, and tools running in those environments shouldn't have automatic access to tokens unless absolutely necessary.
+**Prevention:** Explicitly strip sensitive environment variables (like `GH_TOKEN`) before invoking third-party CLI commands or running user-configurable shell scripts.


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `GH_TOKEN` environment variable was being passed to all shell commands executed via `run_shell_command` in `repository_automation_common.py`. This exposed the token to potentially compromised third-party dependencies/tools running in the CI/CD pipeline (e.g. `pytest`, `pre-commit`, `bandit`).
🎯 Impact: A compromised dependency could read the `GH_TOKEN` from its environment and exfiltrate it, granting an attacker access to the repository with the token's privileges.
🔧 Fix: Updated `run_process` to accept an optional `env` argument. Modified `run_shell_command` to construct a safe environment dictionary by explicitly popping `GH_TOKEN` before calling `run_process`. This implements the principle of least privilege. Documented this pattern in `.jules/sentinel.md`.
✅ Verification: Ran `python3 -m py_compile .github/scripts/repository_automation_common.py` to ensure there are no syntax errors.

---
*PR created automatically by Jules for task [15673205587239250791](https://jules.google.com/task/15673205587239250791) started by @abhimehro*