### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix subprocess credential exfiltration risk

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -61,6 +61,7 @@ def run_process(
     input_text: str | None = None,
     timeout: int = 300,
     check: bool = False,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         command,
@@ -70,13 +71,18 @@ def run_process(
         text=True,
         input=input_text,
         timeout=timeout,
-        env=command_env(),
+        env=env if env is not None else command_env(),
     )
 
 
 def run_shell_command(command: str, timeout: int = 1800) -> dict[str, Any]:
+    # SECURITY: Strip GH_TOKEN to enforce least privilege and prevent credential
+    # exfiltration by potentially compromised third-party dependencies executed in the shell.
+    safe_env = command_env()
+    safe_env.pop("GH_TOKEN", None)
+
     # Commands originate from repository-controlled configuration, not user input.
-    proc = run_process([BASH_BIN, "-lc", command], timeout=timeout)
+    proc = run_process([BASH_BIN, "-lc", command], timeout=timeout, env=safe_env)
     return {
         "command": command,
         "exit_code": proc.returncode,

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -74,3 +74,9 @@
 **Vulnerability:** Using `exc_info=True` in generic exception handlers (`except Exception as exc:`) logs the full stack trace and exception details, which can unintentionally leak sensitive internal application paths, state, environment variables, or database queries depending on the underlying error.
 **Learning:** While `exc_info=True` aids debugging, its use in high-level generic exception blocks constitutes an information disclosure risk, particularly when logs are accessible to less privileged users or centralized logging systems.
 **Prevention:** Avoid `exc_info=True` in broad exception handlers. Fail securely by logging a generic user-facing message, and include only the exception type (e.g., `type(exc).__name__`) to preserve debuggability without exposing sensitive string contents or stack traces.
+
+## 2025-08-12 - Dependency Credential Exfiltration Risk in Automated Shell Environments
+
+**Vulnerability:** When executing external or third-party CLI tools (e.g., linters, formatters, test runners) via `subprocess` in automated pipelines, the default behavior of passing the entire current environment `os.environ` can inadvertently expose sensitive credentials, such as `GH_TOKEN`, to potentially compromised third-party dependencies executing in the shell.
+**Learning:** The principle of least privilege should be enforced not only for the application code but also for the environment variables passed to any invoked sub-processes. Third-party tools do not need access to the repository's GitHub token unless explicitly required for their function.
+**Prevention:** Always explicitly strip sensitive environment variables (e.g., `env.pop("GH_TOKEN", None)`) from the environment dictionary before passing it to `subprocess.run` or `subprocess.Popen` when invoking third-party CLI tools.


### PR DESCRIPTION
## 🚨 Severity
CRITICAL/HIGH

## 💡 Vulnerability
When executing external or third-party CLI tools (like `gh` or `git`) via `subprocess` in automated Python scripts, the default behavior passes the entire `os.environ` to the child process. This inadvertently exposes sensitive credentials, such as `GH_TOKEN`, to the executed third-party binaries. If one of these dependencies or tools were compromised, it could easily exfiltrate the token from its environment.

## 🎯 Impact
Credential exfiltration. A compromised dependency could read `GH_TOKEN` and use it to access or modify the repository and organization without authorization.

## 🔧 Fix
Updated `run_process` to accept an optional `env` argument (defaulting to the command environment). Updated `run_shell_command` to explicitly pop `GH_TOKEN` from the environment dictionary before passing it to `run_process`, ensuring least privilege.

## ✅ Verification
- Analyzed and verified through manual script tests mocking the `subprocess` call to confirm `GH_TOKEN` is stripped from the `env` argument before execution.
- Syntax verification via `python3 -m py_compile`.

---
*PR created automatically by Jules for task [15305993184063610063](https://jules.google.com/task/15305993184063610063) started by @abhimehro*