### PR TITLE
🛡️ Sentinel: [security improvement] Enforce least privilege in run_process

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -63,6 +63,13 @@ def run_process(
     check: bool = False,
     env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
+    proc_env = env if env is not None else command_env()
+    # SECURITY: Strip GH_TOKEN to enforce least privilege and prevent credential
+    # exfiltration by potentially compromised third-party dependencies executed in the shell.
+    if command and command[0] != GH_BIN and "GH_TOKEN" in proc_env:
+        proc_env = proc_env.copy()
+        proc_env.pop("GH_TOKEN", None)
+
     return subprocess.run(
         command,
         cwd=ROOT,
@@ -71,7 +78,7 @@ def run_process(
         text=True,
         input=input_text,
         timeout=timeout,
-        env=env if env is not None else command_env(),
+        env=proc_env,
     )
 
 

--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -66,7 +66,7 @@ def run_process(
     proc_env = env if env is not None else command_env()
     # SECURITY: Strip GH_TOKEN to enforce least privilege and prevent credential
     # exfiltration by potentially compromised third-party dependencies executed in the shell.
-    if command and command[0] != GH_BIN and "GH_TOKEN" in proc_env:
+    if command[0] != GH_BIN and "GH_TOKEN" in proc_env:
         proc_env = proc_env.copy()
         proc_env.pop("GH_TOKEN", None)
 


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Enforce least privilege in run_process

🚨 Severity: MEDIUM
💡 Vulnerability: When executing third-party CLI tools or external processes using `subprocess.run` inside `run_process`, passing the full current environment (which defaults to `command_env()` inheriting from `os.environ`) inadvertently exposes sensitive credentials like the `GH_TOKEN` to those processes.
🎯 Impact: A potentially compromised third-party dependency executed within the automated shell scripts could exfiltrate the GitHub App/PAT token, allowing unauthorized write access to the repository, its issues, and its codebase.
🔧 Fix: Modified `run_process` in `.github/scripts/repository_automation_common.py` to explicitly strip the `GH_TOKEN` from the environment variable dictionary before executing any command that is not explicitly the GitHub CLI (`gh` / `GH_BIN`). This ensures `gh` can authenticate while enforcing the principle of least privilege for all other processes.
✅ Verification: Tested locally by verifying that the `gh` command still executes successfully with the token, but invoking bash or other scripts explicitly fails to access the `GH_TOKEN` environment variable. Also ran `PYTHONPATH=. pytest tests/` which completed cleanly.

═════ ELIR ═════
PURPOSE: Enforces least privilege by preventing credential exposure to non-`gh` commands in the repository automation framework.
SECURITY: Strips `GH_TOKEN` from subprocess environments. Prevents token exfiltration by compromised third-party actions/dependencies.
FAILS IF: A non-`gh` tool intentionally relies on `GH_TOKEN` being passed implicitly via `os.environ` to interact with GitHub APIs.
VERIFY: Confirm that the GitHub CLI (`gh`) still functions normally, while generic shell commands executed by `run_process` cannot see the `GH_TOKEN`.
MAINTAIN: If a new tool needs the token in the future, it must be explicitly allow-listed in the `command[0] != GH_BIN` check.

---
*PR created automatically by Jules for task [1443310050295746957](https://jules.google.com/task/1443310050295746957) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens environment handling for subprocesses, which is security-positive but may break any automation commands that implicitly relied on `GH_TOKEN` being present for non-`gh` tools.
> 
> **Overview**
> Updates `run_process` to enforce least privilege by **removing `GH_TOKEN` from the environment for any subprocess that is not the GitHub CLI (`gh`)**, while still allowing `gh` invocations to authenticate.
> 
> This centralizes token-stripping behavior in `run_process` (in addition to the existing `run_shell_command` safeguard), reducing the chance of credential leakage to third-party commands executed by repository automation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa39c584c07f528fb35882437ab3c7543aeeb3c9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->