### PR TITLE
🧹 Replace hardcoded dummy logic in get_repo_info

### DIFF
--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -1,17 +1,53 @@
 import logging
 import os
+import re
+import subprocess
 
 
 def get_repo_info():
+    """
+    Retrieves the repository account, project name, and current commit hash.
+    Uses git commands to extract information from the local environment.
+    """
     try:
-        # Dummy code
-        return "account", "project", "hash"
+        # SECURITY: Strip GH_TOKEN to prevent exfiltration if subprocess is compromised
+        env = os.environ.copy()
+        env.pop("GH_TOKEN", None)
+
+        # Get origin URL
+        origin_url = subprocess.check_output(
+            ["git", "remote", "get-url", "origin"],
+            stderr=subprocess.DEVNULL,
+            env=env,
+            text=True
+        ).strip()
+
+        # Parse account and project from URL
+        # Matches formats:
+        # https://github.com/account/project.git
+        # git@github.com:account/project.git
+        match = re.search(r"[:/]([^/:]+)/([^/:]+?)(?:\.git)?$", origin_url)
+        if not match:
+            return "unknown", "unknown", "unknown"
+
+        account, project = match.groups()
+
+        # Get current commit hash
+        commit_hash = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            env=env,
+            text=True
+        ).strip()
+
+        return account, project, commit_hash
+
     except Exception as e:
         # SECURITY: Fail securely, don't expose internal exception details
         logging.error(
             f"Error getting repo info: Internal error occurred ({type(e).__name__})."
         )
-        return "account", "project", "hash"
+        return "unknown", "unknown", "unknown"
 
 
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB

--- a/tests/test_code_health_scanner.py
+++ b/tests/test_code_health_scanner.py
@@ -1,12 +1,49 @@
 import os
+import subprocess
+from unittest.mock import patch
 import pytest
 from code_health_scanner import get_repo_info, read_file_safe, get_language, scan_file, MAX_FILE_SIZE
 
-def test_get_repo_info():
-    account, project, commit_hash = get_repo_info()
-    assert account == "account"
-    assert project == "project"
-    assert commit_hash == "hash"
+def test_get_repo_info_https():
+    with patch("subprocess.check_output") as mock_run:
+        mock_run.side_effect = [
+            "https://github.com/account/project.git\n",
+            "hash\n"
+        ]
+        account, project, commit_hash = get_repo_info()
+        assert account == "account"
+        assert project == "project"
+        assert commit_hash == "hash"
+
+def test_get_repo_info_ssh():
+    with patch("subprocess.check_output") as mock_run:
+        mock_run.side_effect = [
+            "git@github.com:account/project.git\n",
+            "hash\n"
+        ]
+        account, project, commit_hash = get_repo_info()
+        assert account == "account"
+        assert project == "project"
+        assert commit_hash == "hash"
+
+def test_get_repo_info_no_dot_git():
+    with patch("subprocess.check_output") as mock_run:
+        mock_run.side_effect = [
+            "https://github.com/account/project\n",
+            "hash\n"
+        ]
+        account, project, commit_hash = get_repo_info()
+        assert account == "account"
+        assert project == "project"
+        assert commit_hash == "hash"
+
+def test_get_repo_info_failure():
+    with patch("subprocess.check_output") as mock_run:
+        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+        account, project, commit_hash = get_repo_info()
+        assert account == "unknown"
+        assert project == "unknown"
+        assert commit_hash == "unknown"
 
 def test_get_language():
     assert get_language("test.py") == "python"
@@ -29,7 +66,6 @@ def test_read_file_safe_happy_path():
 
 def test_read_file_safe_path_traversal():
     # Attempting to read a file outside CWD should return empty list
-    # We use a path that is guaranteed to be outside CWD
     assert read_file_safe("/etc/passwd") == []
 
 def test_read_file_safe_too_large():


### PR DESCRIPTION
🎯 **What:** Replaced the dummy `get_repo_info` function with actual logic that retrieves the repository account, project name, and current commit hash using `git` commands.

💡 **Why:** Returning hardcoded values indicates incomplete logic and hinders the scanner's ability to provide accurate repository context. Implementing actual retrieval improves the maintainability and accuracy of the tool.

✅ **Verification:** Added comprehensive unit tests in `tests/test_code_health_scanner.py` using mocks to verify parsing of various git URL formats (HTTPS, SSH) and proper error handling. All 12 tests passed successfully.

✨ **Result:** `get_repo_info` now dynamically retrieves repository information from the environment, making the code health scanner more robust and ready for real-world use.

═════ ELIR ═════
PURPOSE: Implements actual git repository info retrieval in `get_repo_info` using `subprocess` and `re`.
SECURITY: Strips `GH_TOKEN` from environment before calling git and logs only exception types to prevent info disclosure.
FAILS IF: `git` is not installed or the directory is not a git repo (returns "unknown" values).
VERIFY: Run `pytest tests/test_code_health_scanner.py`.
MAINTAIN: Regex handles standard GitHub HTTPS/SSH URL formats.

---
*PR created automatically by Jules for task [14172787027687589562](https://jules.google.com/task/14172787027687589562) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->