### PR TITLE
🧹 [code health] Remove useless pass block in code_health_scanner.py

### DIFF
--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -83,5 +83,3 @@ def scan_file(filepath, lines, account, project, commit_hash):
     return issues
 
 
-if __name__ == "__main__":
-    pass

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,13 +1,6 @@
-💡 What
-Replaced a dictionary lookup with `.endswith()` string matching in the `get_language` function of `code_health_scanner.py`.
+🧹 [code health] Remove useless pass block in code_health_scanner.py
 
-🎯 Why
-Using `.endswith()` is evaluated at the C level in Python, eliminating the need to parse the path with `os.path.splitext()`, convert it to lowercase, and perform a dictionary hash lookup. This reduces string allocation overhead when scanning many files.
-
-📊 Measured Improvement
-Execution time for `get_language` is reduced by approximately 57% compared to the original `splitext` approach.
-
-🔬 Measurement
-Ran a test script processing an array of 60,000 filenames.
-- `splitext` approach: 0.0872s
-- `endswith` approach: 0.0372s
+🎯 **What:** Removed the empty `if __name__ == "__main__": pass` block from the end of `code_health_scanner.py`.
+💡 **Why:** This block was useless dead code that served no functional purpose. Removing it improves code maintainability and cleanliness.
+✅ **Verification:** Ran the test suite (`pytest tests/test_code_health_scanner.py`) which completed successfully. No functionality was altered.
+✨ **Result:** A slightly cleaner and more concise file without unnecessary boilerplate.


### PR DESCRIPTION
🎯 **What:** Removed the empty `if __name__ == "__main__": pass` block from the end of `code_health_scanner.py`.
💡 **Why:** This block was useless dead code that served no functional purpose. Removing it improves code maintainability and cleanliness.
✅ **Verification:** Ran the test suite (`pytest tests/test_code_health_scanner.py`) which completed successfully. No functionality was altered.
✨ **Result:** A slightly cleaner and more concise file without unnecessary boilerplate.

---
*PR created automatically by Jules for task [10314576365027032854](https://jules.google.com/task/10314576365027032854) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->