### PR TITLE
🧪 Add test for max file size limit in read_sensor_data

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,11 +1,9 @@
-💡 What
-Replaced the `filepath.endswith(('.py', '.pY', '.Py', '.PY'))` file extension check with the idiomatic `os.path.splitext(filepath)[1].lower()` in `code_health_scanner.py`.
+🎯 **What:**
+Added a test to cover the memory boundary check (max file size constraint) in `read_sensor_data`.
 
-🎯 Why
-Using `.endswith()` with case permutations creates a combinatorial explosion of cases (e.g., a 4-letter extension requires 16 permutations), which is an unmaintainable anti-pattern that sacrifices code readability for negligible performance gains.
+📊 **Coverage:**
+- Ensures the 50MB maximum file limit check correctly throws an error.
+- Validates that `MAX_FILE_SIZE` handling in `Updated_Seatek_Analysis.R` works and catches large files.
 
-📊 Impact
-Slightly increased object allocation during file path parsing but significantly improved code readability and maintainability.
-
-🔬 Measurement
-Tests pass and the logic correctly handles file extension checks case-insensitively, preventing hard-to-read permutations while maintaining accuracy.
+✨ **Result:**
+The `read_sensor_data` function is now fully covered regarding the security constraint of out-of-memory denial of service prevention, increasing overall test reliability.

--- a/tests/testthat/test-read_sensor_data.R
+++ b/tests/testthat/test-read_sensor_data.R
@@ -83,3 +83,25 @@ test_that("read_sensor_data correctly converts numeric timestamps", {
 #   expect_true("Timestamp" %in% names(dt))
 #   expect_equal(names(dt)[33], "Timestamp")
 # })
+
+test_that("read_sensor_data enforces the 50MB maximum file size limit", {
+  # Create a sparse file that is slightly larger than 50MB
+  large_file <- tempfile(fileext = ".txt")
+  f <- file(large_file, "wb")
+  # 50 MB + 1 byte
+  seek(f, 50 * 1024 * 1024 + 1)
+  writeBin(as.raw(0), f)
+  close(f)
+
+  # Ensure cleanup happens even if the test fails
+  on.exit({
+    suppressWarnings(file.remove(large_file))
+  }, add = TRUE)
+
+  # Should throw an error about maximum allowed size
+  expect_error(
+    read_sensor_data(large_file),
+    "exceeds maximum allowed size of 50 MB",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
🎯 **What:** 
Added a test to cover the memory boundary check (max file size constraint) in `read_sensor_data`.

📊 **Coverage:**
- Ensures the 50MB maximum file limit check correctly throws an error.
- Validates that `MAX_FILE_SIZE` handling in `Updated_Seatek_Analysis.R` works and catches large files.

✨ **Result:**
The `read_sensor_data` function is now fully covered regarding the security constraint of out-of-memory denial of service prevention, increasing overall test reliability.

---
*PR created automatically by Jules for task [12750136109594970888](https://jules.google.com/task/12750136109594970888) started by @abhimehro*