### PR TITLE
test: write_year_sheet + read_sensor_data limits (salvages #218, #219, v3)

### DIFF
--- a/tests/testthat/test-read_sensor_data.R
+++ b/tests/testthat/test-read_sensor_data.R
@@ -83,3 +83,25 @@ test_that("read_sensor_data correctly converts numeric timestamps", {
 #   expect_true("Timestamp" %in% names(dt))
 #   expect_equal(names(dt)[33], "Timestamp")
 # })
+
+test_that("read_sensor_data enforces the 50MB maximum file size limit", {
+  # Create a sparse file that is slightly larger than 50MB
+  large_file <- tempfile(fileext = ".txt")
+  f <- file(large_file, "wb")
+  # 50 MB + 1 byte
+  seek(f, 50 * 1024 * 1024 + 1)
+  writeBin(as.raw(0), f)
+  close(f)
+
+  # Ensure cleanup happens even if the test fails
+  on.exit({
+    suppressWarnings(file.remove(large_file))
+  }, add = TRUE)
+
+  # Should throw an error about maximum allowed size
+  expect_error(
+    read_sensor_data(large_file),
+    "exceeds maximum allowed size of 50 MB",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-write_year_sheet.R
+++ b/tests/testthat/test-write_year_sheet.R
@@ -1,0 +1,65 @@
+library(testthat)
+library(openxlsx)
+library(data.table)
+
+# Use the global variables if needed, assuming the testthat.R setup has loaded them.
+# The `Updated_Seatek_Analysis.R` contains the `write_year_sheet` function.
+# To make it available here reliably, let's also source it.
+if (file.exists("../../Updated_Seatek_Analysis.R")) {
+  source("../../Updated_Seatek_Analysis.R")
+} else if (file.exists("Updated_Seatek_Analysis.R")) {
+  source("Updated_Seatek_Analysis.R")
+}
+
+test_that("write_year_sheet works correctly", {
+  # Create a new workbook
+  wb <- createWorkbook()
+
+  # Create some mock data
+  mock_data <- data.table(
+    Sensor = c("Sensor01", "Sensor02"),
+    first10 = c(10.5, 12.3),
+    last5 = c(11.0, 11.5),
+    full = c(10.8, 12.0),
+    within_diff = c(0.5, -0.8)
+  )
+
+  # Create mock styles
+  header_style <- createStyle(textDecoration = "Bold", border = "Bottom")
+  highlight_style_yearly <- createStyle(fontColour = "#006100", bgFill = "#C6EFCE")
+
+  # Call the function
+  year <- "2023"
+  write_year_sheet(wb, year, mock_data, header_style, highlight_style_yearly)
+
+  # 1. Check if sheet was added
+  expect_true(year %in% names(wb), label = "Sheet should be added to the workbook.")
+
+  # 2. Read data back and verify
+  temp_file <- tempfile(fileext = ".xlsx")
+  saveWorkbook(wb, temp_file, overwrite = TRUE)
+
+  read_data <- read.xlsx(temp_file, sheet = year)
+
+  # Verify dimensions
+  expect_equal(nrow(read_data), nrow(mock_data), label = "Number of rows should match.")
+  expect_equal(ncol(read_data), ncol(mock_data), label = "Number of columns should match.")
+
+  # Verify specific values
+  expect_equal(read_data$Sensor, mock_data$Sensor, label = "Sensor column should match.")
+  expect_equal(read_data$within_diff, mock_data$within_diff, label = "within_diff column should match.")
+
+  # 3. Test without highlight style (should not fail)
+  wb2 <- createWorkbook()
+  write_year_sheet(wb2, "2024", mock_data, header_style, NULL)
+  expect_true("2024" %in% names(wb2), label = "Sheet should be added even without highlight style.")
+
+  # 4. Test without 'within_diff' column (should not fail and shouldn't try to highlight)
+  wb3 <- createWorkbook()
+  mock_data_no_diff <- mock_data[, -c("within_diff")]
+  write_year_sheet(wb3, "2025", mock_data_no_diff, header_style, highlight_style_yearly)
+  expect_true("2025" %in% names(wb3), label = "Sheet should be added even without within_diff column.")
+
+  # Cleanup
+  if (file.exists(temp_file)) file.remove(temp_file)
+})

--- a/tests/testthat/testthat.R
+++ b/tests/testthat/testthat.R
@@ -1,21 +1,17 @@
 library(testthat)
-if (interactive()) {
-  library(Seatek_Analysis) # Assuming the main script can be sourced or treated as a package
+
+# When sourcing testthat.R, it sources the main file into the parent environment
+# so the test scripts have access to it.
+env <- globalenv()
+
+if (file.exists("Updated_Seatek_Analysis.R")) {
+  source("Updated_Seatek_Analysis.R", local=env)
+} else if (file.exists("../../Updated_Seatek_Analysis.R")) {
+  source("../../Updated_Seatek_Analysis.R", local=env)
+} else {
+  stop("Main analysis script not found.")
 }
 
-# Get the path to the main analysis script
-# This might need adjustment based on how Updated_Seatek_Analysis.R is structured
-# and whether its functions are globally available or need explicit sourcing.
-# For now, let's assume functions are available after sourcing.
-script_path <- normalizePath("../../Updated_Seatek_Analysis.R")
-if (!file.exists(script_path)) {
-  stop(paste("Main analysis script not found at:", script_path))
-}
-source(script_path) # Source the script to make functions available
-
-# Run all tests in the directory when executed interactively
-# The workflow calls `testthat::test_dir()` externally, so we avoid
-# re-invoking it here to prevent nested calls and related errors.
 if (interactive()) {
   test_dir(".", stop_on_failure = TRUE)
   print("testthat.R executed: All tests in tests/testthat will be run.")


### PR DESCRIPTION
## Purpose
Combined minimal test salvage for #218 and #219 on current `main` (no workflow/journal noise).

## Verify
```bash
Rscript -e "library(testthat); test_file('tests/testthat/test-write_year_sheet.R'); test_file('tests/testthat/test-read_sensor_data.R')"
```

Supersedes #223 and #224 (closing).