### PR TITLE
🧹 Remove unused get_repo_info function

### DIFF
--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -1,53 +1,5 @@
 import logging
 import os
-import re
-import subprocess
-
-
-def get_repo_info():
-    """
-    Retrieves the repository account, project name, and current commit hash.
-    Uses git commands to extract information from the local environment.
-    """
-    try:
-        # SECURITY: Strip GH_TOKEN to prevent exfiltration if subprocess is compromised
-        env = os.environ.copy()
-        env.pop("GH_TOKEN", None)
-
-        # Get origin URL
-        origin_url = subprocess.check_output(
-            ["git", "remote", "get-url", "origin"],
-            stderr=subprocess.DEVNULL,
-            env=env,
-            text=True
-        ).strip()
-
-        # Parse account and project from URL
-        # Matches formats:
-        # https://github.com/account/project.git
-        # git@github.com:account/project.git
-        match = re.search(r"[:/]([^/:]+)/([^/:]+?)(?:\.git)?$", origin_url)
-        if not match:
-            return "unknown", "unknown", "unknown"
-
-        account, project = match.groups()
-
-        # Get current commit hash
-        commit_hash = subprocess.check_output(
-            ["git", "rev-parse", "HEAD"],
-            stderr=subprocess.DEVNULL,
-            env=env,
-            text=True
-        ).strip()
-
-        return account, project, commit_hash
-
-    except Exception as e:
-        # SECURITY: Fail securely, don't expose internal exception details
-        logging.error(
-            f"Error getting repo info: Internal error occurred ({type(e).__name__})."
-        )
-        return "unknown", "unknown", "unknown"
 
 
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
@@ -101,7 +53,7 @@ def get_language(filepath):
     return 'unknown'
 
 
-def scan_file(filepath, lines, account, project, commit_hash):
+def scan_file(filepath, lines):
     issues = []
 
     # Determine language

--- a/tests/test_code_health_scanner.py
+++ b/tests/test_code_health_scanner.py
@@ -2,48 +2,7 @@ import os
 import subprocess
 from unittest.mock import patch
 import pytest
-from code_health_scanner import get_repo_info, read_file_safe, get_language, scan_file, MAX_FILE_SIZE
-
-def test_get_repo_info_https():
-    with patch("subprocess.check_output") as mock_run:
-        mock_run.side_effect = [
-            "https://github.com/account/project.git\n",
-            "hash\n"
-        ]
-        account, project, commit_hash = get_repo_info()
-        assert account == "account"
-        assert project == "project"
-        assert commit_hash == "hash"
-
-def test_get_repo_info_ssh():
-    with patch("subprocess.check_output") as mock_run:
-        mock_run.side_effect = [
-            "git@github.com:account/project.git\n",
-            "hash\n"
-        ]
-        account, project, commit_hash = get_repo_info()
-        assert account == "account"
-        assert project == "project"
-        assert commit_hash == "hash"
-
-def test_get_repo_info_no_dot_git():
-    with patch("subprocess.check_output") as mock_run:
-        mock_run.side_effect = [
-            "https://github.com/account/project\n",
-            "hash\n"
-        ]
-        account, project, commit_hash = get_repo_info()
-        assert account == "account"
-        assert project == "project"
-        assert commit_hash == "hash"
-
-def test_get_repo_info_failure():
-    with patch("subprocess.check_output") as mock_run:
-        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
-        account, project, commit_hash = get_repo_info()
-        assert account == "unknown"
-        assert project == "unknown"
-        assert commit_hash == "unknown"
+from code_health_scanner import read_file_safe, get_language, scan_file, MAX_FILE_SIZE
 
 def test_get_language():
     assert get_language("test.py") == "python"
@@ -85,32 +44,18 @@ def test_read_file_safe_non_existent():
 def test_scan_file_python_todo():
     filepath = "test.py"
     lines = ["print('hello')\n", "print('TODO')\n", "TODO\n"]
-    issues = scan_file(filepath, lines, "acc", "proj", "hash")
+    issues = scan_file(filepath, lines)
     assert len(issues) == 1
     assert "TODO in test.py:2" in issues[0]
 
 def test_scan_file_python_no_todo():
     filepath = "test.py"
     lines = ["print('hello')\n", "# TODO: fix this\n"]
-    issues = scan_file(filepath, lines, "acc", "proj", "hash")
+    issues = scan_file(filepath, lines)
     assert issues == []
 
 def test_scan_file_unknown_lang():
     filepath = "test.unknown"
     lines = ["print('TODO')\n"]
-    issues = scan_file(filepath, lines, "acc", "proj", "hash")
+    issues = scan_file(filepath, lines)
     assert issues == []
-
-def test_get_repo_info_exception_logging(caplog):
-    import logging
-    with patch("subprocess.check_output") as mock_run:
-        mock_run.side_effect = Exception("Some secret internal error")
-        with caplog.at_level(logging.ERROR):
-            account, project, commit_hash = get_repo_info()
-
-        assert account == "unknown"
-        assert project == "unknown"
-        assert commit_hash == "unknown"
-
-        assert "Error getting repo info: Internal error occurred (Exception)." in caplog.text
-        assert "Some secret internal error" not in caplog.text


### PR DESCRIPTION
🎯 **What:** Removed the unused `get_repo_info` function and its dependencies (`re`, `subprocess`) from `code_health_scanner.py`. Cleaned up the `scan_file` function signature by removing unused parameters (`account`, `project`, `commit_hash`). Updated the corresponding tests to reflect these changes.
💡 **Why:** `get_repo_info` was dead code, never referenced within the module or elsewhere. The `scan_file` function accepted arguments it never used. Removing these reduces clutter, improving maintainability and readability.
✅ **Verification:** Verified that `scan_file` signature updates are correct, tests pass successfully (`pytest tests/`), and no references remain.
✨ **Result:** A cleaner, more maintainable codebase with reduced dead code.

═════ ELIR ═════
PURPOSE: Removes the unused `get_repo_info` function and cleans up the `scan_file` signature to improve maintainability and remove dead code.
SECURITY: N/A - Removed dead code, reducing attack surface slightly.
FAILS IF: Tests were not updated correctly, but they have been and pass.
VERIFY: Confirm `get_repo_info` is removed, imports are cleaned up, and `scan_file` takes only `filepath` and `lines`.
MAINTAIN: Keep function signatures aligned with their actual usage to prevent confusion.

---
*PR created automatically by Jules for task [2452553303530882034](https://jules.google.com/task/2452553303530882034) started by @abhimehro*