### PR TITLE
🧹 [code health] Extract helper functions from write_summary_sheets

### DIFF
--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -284,81 +284,79 @@ calculate_summary_stats <- function(results) {
   summary_wide # Implicit return
 }
 
-# Write summary sheets and CSVs
-write_summary_sheets <- function(wb, summary_df, output_file,
-                                 header_style, highlight_top_n, highlight_style_summary = NULL) {
-  # --- Comprehensive summary (all sensors) ---
-  summary_df_all <- summary_df # keep a copy before filtering
+# Write comprehensive summary (all sensors)
+export_comprehensive_summary <- function(wb, summary_df_all, output_file,
+                                         header_style) {
   addWorksheet(wb, "Summary_All")
   writeData(wb, sheet = "Summary_All", x = summary_df_all,
             headerStyle = header_style)
   freezePane(wb, sheet = "Summary_All", firstRow = TRUE)
-  # Export comprehensive summary as CSV
+
   csv_all <- sub("\\.xlsx$", "_all.csv", output_file)
   data.table::fwrite(summary_df_all, csv_all, row.names = FALSE)
   message(sprintf("Comprehensive summary CSV written to %s", csv_all))
   cat(sprintf("  📄 Saved: %s\n", basename(csv_all)))
+}
 
-  # --- Filtered summary (sufficient data only) ---
-  min_count <- 5
-  summary_df_sufficient <-
-    summary_df_all[summary_df_all$full_count >= min_count, ]
+# Write filtered summary (sufficient data only)
+export_sufficient_summary <- function(wb, summary_df_sufficient, output_file,
+                                      header_style) {
   addWorksheet(wb, "Summary_Sufficient")
   writeData(wb, sheet = "Summary_Sufficient", x = summary_df_sufficient,
             headerStyle = header_style)
   freezePane(wb, sheet = "Summary_Sufficient", firstRow = TRUE)
-  # Export filtered summary as CSV
+
   csv_sufficient <- sub("\\.xlsx$", "_sufficient.csv", output_file)
   data.table::fwrite(summary_df_sufficient, csv_sufficient, row.names = FALSE)
   message(sprintf("Filtered summary CSV written to %s", csv_sufficient))
   cat(sprintf("  📄 Saved: %s\n", basename(csv_sufficient)))
+}
 
-  # Continue with filtered summary for top sensors and highlighting
-  summary_df <- summary_df_sufficient
-  # Flag high-variability sensors (e.g., full_sd > threshold)
-  sd_threshold <- 2 # adjust as needed
-  # Modifying in place if data.table
+# Write top sensors summary
+export_top_sensors_summary <- function(wb, summary_df, output_file,
+                                       header_style) {
+  if (!"within_diff_mean" %in% colnames(summary_df)) return()
+
+  abs_diff <- abs(summary_df$within_diff_mean)
+  top_n <- 5
+  cols_to_keep <- c(
+    "Sensor", "within_diff_mean",
+    "full_mean", "full_sd",
+    "full_pct_nonmissing"
+  )
   if (is.data.table(summary_df)) {
-    summary_df[, flag_high_variability := full_sd > sd_threshold]
+    top_sensors <- summary_df[order(-abs_diff)][1:top_n, ..cols_to_keep]
   } else {
-    summary_df$flag_high_variability <- summary_df$full_sd > sd_threshold
+    top_sensors <- summary_df[order(-abs_diff), ][1:top_n, cols_to_keep]
   }
 
-  # Prepare top sensors by absolute within_diff_mean
-  if ("within_diff_mean" %in% colnames(summary_df)) {
-    abs_diff <- abs(summary_df$within_diff_mean)
-    top_n <- 5
-    cols_to_keep <- c(
-      "Sensor", "within_diff_mean",
-      "full_mean", "full_sd",
-      "full_pct_nonmissing"
-    )
-    if (is.data.table(summary_df)) {
-      top_sensors <- summary_df[order(-abs_diff)][1:top_n, ..cols_to_keep]
-    } else {
-      top_sensors <- summary_df[order(-abs_diff), ][1:top_n, cols_to_keep]
-    }
-    csv_top <- sub("\\.xlsx$", "_top_sensors.csv", output_file)
-    data.table::fwrite(top_sensors, csv_top, row.names = FALSE)
-    cat(sprintf("  📄 Saved: %s\n", basename(csv_top)))
+  csv_top <- sub("\\.xlsx$", "_top_sensors.csv", output_file)
+  data.table::fwrite(top_sensors, csv_top, row.names = FALSE)
+  cat(sprintf("  📄 Saved: %s\n", basename(csv_top)))
 
-    addWorksheet(wb, "Summary_Top_Sensors")
-    writeData(
-      wb,
-      sheet = "Summary_Top_Sensors",
-      x = top_sensors,
-      headerStyle = header_style
-    )
-    freezePane(wb, sheet = "Summary_Top_Sensors", firstRow = TRUE)
-    setColWidths(wb, sheet = "Summary_Top_Sensors", cols = 1:ncol(top_sensors),
-                 widths = "auto")
-  }
+  addWorksheet(wb, "Summary_Top_Sensors")
+  writeData(
+    wb,
+    sheet = "Summary_Top_Sensors",
+    x = top_sensors,
+    headerStyle = header_style
+  )
+  freezePane(wb, sheet = "Summary_Top_Sensors", firstRow = TRUE)
+  setColWidths(wb, sheet = "Summary_Top_Sensors", cols = 1:ncol(top_sensors),
+               widths = "auto")
+}
 
+# Write main summary sheet and CSVs
+export_main_summary <- function(wb, summary_df, output_file,
+                                header_style, highlight_top_n,
+                                highlight_style_summary = NULL) {
   addWorksheet(wb, "Summary")
   writeData(wb, sheet = "Summary", x = summary_df, headerStyle = header_style)
   freezePane(wb, sheet = "Summary", firstRow = TRUE)
+
   # Highlight top N sensors with largest absolute within_diff_mean
-  if ("within_diff_mean" %in% colnames(summary_df) && !is.null(highlight_style_summary)) {
+  if ("within_diff_mean" %in% colnames(summary_df) &&
+        !is.null(highlight_style_summary)) {
     abs_diff <- abs(summary_df$within_diff_mean)
     top_idx <- order(abs_diff, decreasing = TRUE)[
       seq_len(min(highlight_top_n, length(abs_diff)))
@@ -371,16 +369,52 @@ write_summary_sheets <- function(wb, summary_df, output_file,
   saveWorkbook(wb, output_file, overwrite = TRUE)
   message(sprintf("Summary written to %s", output_file))
   cat(sprintf("  📄 Saved: %s\n", basename(output_file)))
+
   # Also export summary as CSV for preview
   csv_out <- sub("\\.xlsx$", ".csv", output_file)
   data.table::fwrite(summary_df, csv_out, row.names = FALSE)
   message(sprintf("Summary CSV written to %s", csv_out))
   cat(sprintf("  📄 Saved: %s\n", basename(csv_out)))
+
   # Export robust stats as CSV
   csv_robust <- sub("\\.xlsx$", "_robust.csv", output_file)
   data.table::fwrite(summary_df, csv_robust, row.names = FALSE)
   message(sprintf("Robust summary CSV written to %s", csv_robust))
   cat(sprintf("  📄 Saved: %s\n", basename(csv_robust)))
+}
+
+# Write summary sheets and CSVs
+write_summary_sheets <- function(wb, summary_df, output_file,
+                                 header_style, highlight_top_n,
+                                 highlight_style_summary = NULL) {
+  # --- Comprehensive summary (all sensors) ---
+  summary_df_all <- summary_df # keep a copy before filtering
+  export_comprehensive_summary(wb, summary_df_all, output_file, header_style)
+
+  # --- Filtered summary (sufficient data only) ---
+  min_count <- 5
+  summary_df_sufficient <- summary_df_all[
+    summary_df_all$full_count >= min_count,
+  ]
+  export_sufficient_summary(wb, summary_df_sufficient, output_file,
+                            header_style)
+
+  # Continue with filtered summary for top sensors and highlighting
+  summary_df <- summary_df_sufficient
+
+  # Flag high-variability sensors (e.g., full_sd > threshold)
+  sd_threshold <- 2 # adjust as needed
+  # Modifying in place if data.table
+  if (is.data.table(summary_df)) {
+    summary_df[, flag_high_variability := full_sd > sd_threshold]
+  } else {
+    summary_df$flag_high_variability <- summary_df$full_sd > sd_threshold
+  }
+
+  export_top_sensors_summary(wb, summary_df, output_file, header_style)
+
+  export_main_summary(wb, summary_df, output_file, header_style,
+                      highlight_top_n, highlight_style_summary)
 }
 
 # Write combined summary workbook


### PR DESCRIPTION
🎯 **What:** The `write_summary_sheets` function in `Updated_Seatek_Analysis.R` was overly long and complex, handling multiple summary generation responsibilities. It has been refactored by extracting its core responsibilities into four distinct helper functions: `export_comprehensive_summary`, `export_sufficient_summary`, `export_top_sensors_summary`, and `export_main_summary`.

💡 **Why:** Splitting this monolithic function into smaller, well-named helpers significantly improves readability, maintainability, and modularity. Each helper now has a single, clear responsibility, making it easier to understand and test individual pieces of the summary generation logic.

✅ **Verification:** Ran `lintr` and the full `testthat` suite to ensure the refactored code adheres to style guidelines (like the 80 character line limit) and preserves all existing functionality. Code review indicated a `Correct` implementation.

✨ **Result:** Improved code structure and modularity in `Updated_Seatek_Analysis.R` without altering its behavior.

---
*PR created automatically by Jules for task [7289086197135619217](https://jules.google.com/task/7289086197135619217) started by @abhimehro*