### PR TITLE
🧹 Remove unused pytest import in test_code_health_scanner.py

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,7 +1,4 @@
-**🚨 Severity:** HIGH
-**💡 Vulnerability:** The subprocess execution wrappers (`run_process` and `run_shell_command`) in `.github/scripts/repository_automation_common.py` used an incomplete denylist (`env.pop("GH_TOKEN")`) to sanitize the environment before executing external commands. This left other sensitive tokens commonly used in CI (such as `GITHUB_TOKEN`) vulnerable to exfiltration by compromised third-party dependencies executed in the shell.
-**🎯 Impact:** A compromised external script or dependency executed via these wrappers could access and exfiltrate the `GITHUB_TOKEN`, potentially leading to unauthorized access, code modification, or further lateral movement within the repository and organization.
-**🔧 Fix:** Expanded the denylist in both `run_process` and `run_shell_command` to explicitly strip out `GITHUB_TOKEN` in addition to `GH_TOKEN`. While a strict allowlist is conceptually safer, it was verified to break essential tools that rely on standard CI/OS environment variables (like `PATH`, `HOME`, and `GITHUB_WORKSPACE`). Therefore, a comprehensive denylist approach was maintained and augmented. Also added a journal entry in `.jules/sentinel.md` documenting this finding and the trade-offs.
-**✅ Verification:**
-1. Execute tests: `PYTHONPATH=. pytest tests/`
-2. Verified that locally constructed dummy tokens for `GH_TOKEN` and `GITHUB_TOKEN` are stripped from subprocess outputs when executing commands like `env`.
+🎯 **What:** Removed unused `import pytest` from `tests/test_code_health_scanner.py`.
+💡 **Why:** The `pytest` module was imported but not referenced anywhere in the file. Removing unused imports reduces clutter, improves namespace cleanliness, and slightly decreases module loading overhead, enhancing overall code maintainability and readability.
+✅ **Verification:** Ran the full test suite (`PYTHONPATH=. pytest tests/`) to confirm that all tests continue to pass without the import.
+✨ **Result:** The code is cleaner without any change to the existing test functionality or behavior.

--- a/tests/test_code_health_scanner.py
+++ b/tests/test_code_health_scanner.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
 from unittest.mock import patch
-import pytest
 from code_health_scanner import get_repo_info, read_file_safe, get_language, MAX_FILE_SIZE
 
 def test_get_repo_info_https():


### PR DESCRIPTION
🎯 **What:** Removed unused `import pytest` from `tests/test_code_health_scanner.py`.
💡 **Why:** The `pytest` module was imported but not referenced anywhere in the file. Removing unused imports reduces clutter, improves namespace cleanliness, and slightly decreases module loading overhead, enhancing overall code maintainability and readability.
✅ **Verification:** Ran the full test suite (`PYTHONPATH=. pytest tests/`) to confirm that all tests continue to pass without the import.
✨ **Result:** The code is cleaner without any change to the existing test functionality or behavior.

---
*PR created automatically by Jules for task [1396647573776044879](https://jules.google.com/task/1396647573776044879) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->