### PR TITLE
docs: add libuv1-dev + fast R package setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,10 @@ Seatek Analysis is an R-based data analysis pipeline for processing Seatek senso
 ### Non-obvious Caveats
 
 - R 4.3.3 is required (matches `renv.lock`). Ubuntu Noble's `r-base` package provides this version.
-- System libraries `libgit2-dev`, `pandoc`, `libcurl4-openssl-dev`, `libxml2-dev`, `libssl-dev`, `libfontconfig1-dev`, `libharfbuzz-dev`, `libfribidi-dev` must be installed before `renv::restore()` succeeds.
+- System libraries `libgit2-dev`, `pandoc`, `libcurl4-openssl-dev`, `libxml2-dev`, `libssl-dev`, `libfontconfig1-dev`, `libharfbuzz-dev`, `libfribidi-dev`, and `libuv1-dev` must be installed before `renv::restore()` succeeds. `libuv1-dev` in particular is required to build `fs` (and therefore `testthat`/`lintr`); without it those package installs fail with `fatal error: uv.h: No such file or directory`.
 - `renv::restore()` installs packages from the lockfile. Additional packages for linting/testing (`testthat`, `lintr`, `logger`, etc.) must be installed separately if not fully captured in `renv.lock`.
+- The full lockfile has ~129 packages (tidyverse, lintr, etc.) and a from-source `renv::restore()` is very slow. The main analysis script `Updated_Seatek_Analysis.R` only needs `data.table` and `openxlsx` (plus base-R `parallel`/`tools`); tests need `testthat` + `openxlsx` + `data.table`; lint needs `lintr`. For a fast setup, install just those via the Posit binary mirror: `Rscript -e 'options(repos=c(CRAN="https://packagemanager.posit.co/cran/__linux__/noble/latest")); install.packages(c("data.table","openxlsx","zoo","here","testthat","lintr"), Ncpus=4)'`. Note the project `.Rprofile` auto-activates `renv`, so package installs land in `renv/library/` for this repo.
+- Running `Rscript Updated_Seatek_Analysis.R` regenerates committed outputs under `Data/` (`Seatek_Summary*.csv/.xlsx`). Run `git checkout -- Data/` afterward to keep the working tree clean.
 - The `lintr` `object_usage_linter` warnings for `Timestamp` and `..sensor_names` in `Updated_Seatek_Analysis.R` are known false positives caused by `data.table` non-standard evaluation.
 - When running in CI (e.g., GitHub Actions) with manual `install.packages()`, set `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE` to prevent renv from interfering.
 - Some existing tests have pre-existing failures due to mismatched error message patterns; these are not environment issues.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cloud-environment setup surfaced a few non-obvious caveats now captured under `## Cursor Cloud specific instructions` in `AGENTS.md`:

- **`libuv1-dev` required**: building `fs` (transitive dep of `testthat`/`lintr`) fails with `fatal error: uv.h: No such file or directory` until `libuv1-dev` is installed. Added it to the system-library list.
- **Fast package setup**: a from-source `renv::restore()` of the ~129-package lockfile is very slow. `Updated_Seatek_Analysis.R` only needs `data.table` + `openxlsx` (plus base-R `parallel`/`tools`); documented the minimal set and a Posit binary-mirror install that is much faster.
- **Clean tree**: `Rscript Updated_Seatek_Analysis.R` regenerates committed `Data/Seatek_Summary*` outputs; noted `git checkout -- Data/`.

## Verification (R 4.3.3 on the cloud VM)

- ✅ `Rscript Updated_Seatek_Analysis.R` — processed 14 sensor files, wrote summary workbook + CSVs.
- ✅ `Rscript -e "library(testthat); source('Updated_Seatek_Analysis.R'); test_dir('tests/testthat', reporter='summary')"` — passed.
- ✅ `lintr::lint('Updated_Seatek_Analysis.R')` — runs (44 style findings, matching known false positives).

Docs-only change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-305f427e-4e89-4172-be3b-5ee784753861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-305f427e-4e89-4172-be3b-5ee784753861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

