### PR TITLE
feat: parse workspace roots from copilot payload

### DIFF
--- a/.github/github-copilot-1password-hooks-bundle/adapters/github-copilot.sh
+++ b/.github/github-copilot-1password-hooks-bundle/adapters/github-copilot.sh
@@ -19,14 +19,17 @@ source "${_ADAPTER_DIR}/_lib.sh"
 normalize_input() {
     local raw_payload="$1"
 
-    local cwd tool_name command workspace_roots_json
+    local cwd tool_name command workspace_roots workspace_roots_json
     cwd=$(extract_json_string "$raw_payload" "cwd")
     tool_name=$(extract_json_string "$raw_payload" "tool_name")
     command=$(extract_json_string "$raw_payload" "command")
 
-    # Copilot currently provides cwd as the single workspace root.
-    # TODO: If Copilot adds multi-root workspace support, parse roots from the payload instead.
-    workspace_roots_json=$(paths_to_json_array "$cwd")
+    # Try workspace_roots array first, fall back to cwd
+    workspace_roots=$(parse_json_workspace_roots "$raw_payload")
+    if [[ -z "$workspace_roots" ]] && [[ -n "$cwd" ]]; then
+        workspace_roots="$cwd"
+    fi
+    workspace_roots_json=$(paths_to_json_array "$workspace_roots")
 
     build_canonical_input \
         "github-copilot" \

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,7 +1,0 @@
-**🚨 Severity:** HIGH
-**💡 Vulnerability:** The subprocess execution wrappers (`run_process` and `run_shell_command`) in `.github/scripts/repository_automation_common.py` used an incomplete denylist (`env.pop("GH_TOKEN")`) to sanitize the environment before executing external commands. This left other sensitive tokens commonly used in CI (such as `GITHUB_TOKEN`) vulnerable to exfiltration by compromised third-party dependencies executed in the shell.
-**🎯 Impact:** A compromised external script or dependency executed via these wrappers could access and exfiltrate the `GITHUB_TOKEN`, potentially leading to unauthorized access, code modification, or further lateral movement within the repository and organization.
-**🔧 Fix:** Expanded the denylist in both `run_process` and `run_shell_command` to explicitly strip out `GITHUB_TOKEN` in addition to `GH_TOKEN`. While a strict allowlist is conceptually safer, it was verified to break essential tools that rely on standard CI/OS environment variables (like `PATH`, `HOME`, and `GITHUB_WORKSPACE`). Therefore, a comprehensive denylist approach was maintained and augmented. Also added a journal entry in `.jules/sentinel.md` documenting this finding and the trade-offs.
-**✅ Verification:**
-1. Execute tests: `PYTHONPATH=. pytest tests/`
-2. Verified that locally constructed dummy tokens for `GH_TOKEN` and `GITHUB_TOKEN` are stripped from subprocess outputs when executing commands like `env`.


### PR DESCRIPTION
Updated the GitHub Copilot adapter to support multi-root workspaces by extracting workspace_roots directly from the Copilot payload, similar to the generic.sh adapter. If workspace_roots is missing, it falls back to cwd.

---
*PR created automatically by Jules for task [17337420393812017896](https://jules.google.com/task/17337420393812017896) started by @abhimehro*