### PR TITLE
🔒 Fix insecure package installation in run_tests.sh

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run --rm -v $(pwd):/app -w /app rocker/r-ver:4.3.0 Rscript -e 'install.packages(c("testthat", "openxlsx", "data.table")); testthat::test_dir("tests/testthat")'
+docker run --rm -v $(pwd):/app -w /app rocker/r-ver:4.3.0 Rscript -e 'install.packages(c("testthat", "openxlsx", "data.table"), repos="https://cloud.r-project.org"); testthat::test_dir("tests/testthat")'


### PR DESCRIPTION
🎯 **What:** The `install.packages()` call in `run_tests.sh` was lacking an explicit repository (`repos`) argument.

⚠️ **Risk:** Calling `install.packages` without specifying a repository can leave the installation vulnerable to Man-In-The-Middle (MITM) attacks if it defaults to an insecure HTTP mirror. Additionally, in headless environments, it can prompt the user for input, leading to script failures or hanging pipelines.

🛡️ **Solution:** Added `repos=\"https://cloud.r-project.org\"` to the `install.packages()` call to explicitly enforce an HTTPS connection to the secure, official CRAN mirror.

═════ ELIR ═════
PURPOSE: Enforce HTTPS for R package installations in the test script.
SECURITY: Prevents MITM attacks by explicitly setting a secure CRAN mirror.
FAILS IF: The specified repository URL becomes unreachable.
VERIFY: Ensure `repos=\"https://cloud.r-project.org\"` is present in the `run_tests.sh` script's `install.packages` call.
MAINTAIN: Always specify secure repositories for package installations in headless scripts.

---
*PR created automatically by Jules for task [3333408900423310226](https://jules.google.com/task/3333408900423310226) started by @abhimehro*