### PR TITLE
🧪 Add edge case test for execute_tasks_parallel progress bar closing on serial fallback error

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,7 +1,11 @@
-**🚨 Severity:** HIGH
-**💡 Vulnerability:** The subprocess execution wrappers (`run_process` and `run_shell_command`) in `.github/scripts/repository_automation_common.py` used an incomplete denylist (`env.pop("GH_TOKEN")`) to sanitize the environment before executing external commands. This left other sensitive tokens commonly used in CI (such as `GITHUB_TOKEN`) vulnerable to exfiltration by compromised third-party dependencies executed in the shell.
-**🎯 Impact:** A compromised external script or dependency executed via these wrappers could access and exfiltrate the `GITHUB_TOKEN`, potentially leading to unauthorized access, code modification, or further lateral movement within the repository and organization.
-**🔧 Fix:** Expanded the denylist in both `run_process` and `run_shell_command` to explicitly strip out `GITHUB_TOKEN` in addition to `GH_TOKEN`. While a strict allowlist is conceptually safer, it was verified to break essential tools that rely on standard CI/OS environment variables (like `PATH`, `HOME`, and `GITHUB_WORKSPACE`). Therefore, a comprehensive denylist approach was maintained and augmented. Also added a journal entry in `.jules/sentinel.md` documenting this finding and the trade-offs.
-**✅ Verification:**
-1. Execute tests: `PYTHONPATH=. pytest tests/`
-2. Verified that locally constructed dummy tokens for `GH_TOKEN` and `GITHUB_TOKEN` are stripped from subprocess outputs when executing commands like `env`.
+🎯 **What:**
+Added missing edge case tests for the `execute_tasks_parallel` function. The function is designed to handle lists of tasks and perform a serial fallback mechanism if parallel namespaces are unavailable. Previously, this fallback lacked test coverage to verify that the progress bar was reliably closed via `finally` if `task_func` failed inside the `tryCatch` loop. We also lacked a test ensuring that an empty list returns immediately.
+
+📊 **Coverage:**
+The test suite now explicitly covers:
+1.  **Empty List:** Passing an empty list `list()` returns `list()` successfully and immediately, avoiding out-of-bounds `txtProgressBar` initialization errors.
+2.  **Serial Fallback Error Bubbling:** Errors triggered during task processing inside the serial fallback correctly bubble up past the wrapper boundary.
+3.  **Graceful Progress Bar Closing:** In the event of an error within the serial fallback `tryCatch` loop, the `finally` block successfully executes, and `close()` is formally invoked on the active progress bar object.
+
+✨ **Result:**
+By filling these testing gaps, the unit test coverage of `execute_tasks_parallel.R` is now significantly more robust. Refactoring and improvements in future work can be applied with confidence knowing edge cases relating to stateful resources (such as `txtProgressBar`) under failure conditions are cleanly asserted.

--- a/tests/testthat/test-execute_tasks_parallel.R
+++ b/tests/testthat/test-execute_tasks_parallel.R
@@ -73,3 +73,97 @@ test_that("execute_tasks_parallel executes gracefully on non-unix platforms", {
     res <- local_env$execute_tasks_parallel_mocked(tasks, function(x) x * 5)
     expect_equal(res, list(5, 10))
 })
+
+test_that("execute_tasks_parallel serial fallback bubbles errors from task_func", {
+    local_env <- new.env(parent = globalenv())
+    local_env$execute_tasks_parallel <- execute_tasks_parallel
+
+    local_env$requireNamespace <- function(package, ...) {
+        if (package == "parallel") return(FALSE)
+        base::requireNamespace(package, ...)
+    }
+
+    environment(local_env$execute_tasks_parallel) <- local_env
+
+    tasks <- list(1, 2, 3)
+
+    failing_task <- function(x) {
+        if (x == 2) stop("Task failed")
+        return(x)
+    }
+
+    suppressMessages(
+        capture.output({
+            expect_error(
+                local_env$execute_tasks_parallel(tasks, failing_task),
+                "Task failed"
+            )
+        })
+    )
+})
+
+test_that("execute_tasks_parallel progress bar is closed on error", {
+    local_env <- new.env(parent = globalenv())
+    local_env$execute_tasks_parallel <- execute_tasks_parallel
+
+    local_env$requireNamespace <- function(package, ...) {
+        if (package == "parallel") return(FALSE)
+        base::requireNamespace(package, ...)
+    }
+
+    environment(local_env$execute_tasks_parallel) <- local_env
+
+    # We need to capture the fact that close() was called on the progress bar.
+    # A simple way to do this is to mock close() or txtProgressBar in the local env.
+
+    pb_created <- FALSE
+    pb_closed <- FALSE
+
+    local_env$txtProgressBar <- function(min, max, style, ...) {
+        pb_created <<- TRUE
+        structure(list(min=min, max=max), class="txtProgressBarMock")
+    }
+
+    local_env$setTxtProgressBar <- function(pb, value) {
+        # do nothing
+    }
+
+    local_env$close <- function(con, ...) {
+        if (inherits(con, "txtProgressBarMock")) {
+            pb_closed <<- TRUE
+        } else {
+            base::close(con, ...)
+        }
+    }
+
+    tasks <- list(1, 2)
+    failing_task <- function(x) {
+        if (x == 2) stop("Task 2 failed")
+        return(x)
+    }
+
+    expect_error(
+        local_env$execute_tasks_parallel(tasks, failing_task),
+        "Task 2 failed"
+    )
+
+    expect_true(pb_created)
+    expect_true(pb_closed)
+})
+
+test_that("execute_tasks_parallel serial fallback handles empty list gracefully", {
+    local_env <- new.env(parent = globalenv())
+    local_env$execute_tasks_parallel <- execute_tasks_parallel
+
+    local_env$requireNamespace <- function(package, ...) {
+        if (package == "parallel") return(FALSE)
+        base::requireNamespace(package, ...)
+    }
+
+    environment(local_env$execute_tasks_parallel) <- local_env
+
+    # An empty list should be returned immediately before the txtProgressBar throws an error
+    # since max (length of tasks) would be 0, violating max > min in txtProgressBar.
+    res <- local_env$execute_tasks_parallel(list(), function(x) x)
+    expect_equal(res, list())
+})


### PR DESCRIPTION
🎯 **What:** 
Added missing edge case tests for the `execute_tasks_parallel` function. The function is designed to handle lists of tasks and perform a serial fallback mechanism if parallel namespaces are unavailable. Previously, this fallback lacked test coverage to verify that the progress bar was reliably closed via `finally` if `task_func` failed inside the `tryCatch` loop. We also lacked a test ensuring that an empty list returns immediately.

📊 **Coverage:**
The test suite now explicitly covers:
1.  **Empty List:** Passing an empty list `list()` returns `list()` successfully and immediately, avoiding out-of-bounds `txtProgressBar` initialization errors.
2.  **Serial Fallback Error Bubbling:** Errors triggered during task processing inside the serial fallback correctly bubble up past the wrapper boundary.
3.  **Graceful Progress Bar Closing:** In the event of an error within the serial fallback `tryCatch` loop, the `finally` block successfully executes, and `close()` is formally invoked on the active progress bar object.

✨ **Result:** 
By filling these testing gaps, the unit test coverage of `execute_tasks_parallel.R` is now significantly more robust. Refactoring and improvements in future work can be applied with confidence knowing edge cases relating to stateful resources (such as `txtProgressBar`) under failure conditions are cleanly asserted.

---
*PR created automatically by Jules for task [10188782055185594424](https://jules.google.com/task/10188782055185594424) started by @abhimehro*