### PR TITLE
chore(test): remove unused pytest import (salvages #276)

### DIFF
--- a/tests/test_code_health_scanner.py
+++ b/tests/test_code_health_scanner.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
 from unittest.mock import patch
-import pytest
 from code_health_scanner import get_repo_info, read_file_safe, get_language, MAX_FILE_SIZE
 
 def test_get_repo_info_https():


### PR DESCRIPTION
## Salvage PR (draft)

Rebuilt from `main` with intent-file-only change after #276 went `CONFLICTING`/`DIRTY`.

### Changes
- Remove unused `pytest` import from `tests/test_code_health_scanner.py`

### Verification
```bash
python3 -m py_compile tests/test_code_health_scanner.py
```

═══ ELIR ═══
PURPOSE: Drop dead import left after test refactors on main.
SECURITY: No runtime change; test-only hygiene.
FAILS IF: `pytest` is actually referenced in the module.
VERIFY: `py_compile` passes; optional `pytest tests/test_code_health_scanner.py`.
MAINTAIN: Intent-file-only salvage — do not checkout Jules journal files.

Closes superseded original: #276