### PR TITLE
autofix: address seq_linter warning in Updated_Seatek_Analysis.R

### DIFF
--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -374,7 +374,7 @@ export_top_sensors_summary <- function(wb, summary_df, output_file,
   )
   freezePane(wb, sheet = "Summary_Top_Sensors", firstRow = TRUE)
   setColWidths(wb,
-    sheet = "Summary_Top_Sensors", cols = 1:ncol(top_sensors),
+    sheet = "Summary_Top_Sensors", cols = seq_len(ncol(top_sensors)),
     widths = "auto"
   )
 }


### PR DESCRIPTION
**Daily QA Review Summary for Seatek_Analysis**

*   **Verification Status:**
    *   Python test suite: **Passed** (14/14 tests passed in `tests/`)
    *   R test suite: **Passed** (168/168 tests passed using `testthat`)
    *   Code Quality: Static analysis using `lintr` revealed a `seq_linter` warning in `Updated_Seatek_Analysis.R` regarding `1:ncol()`. (Other warnings like `Timestamp` `object_usage_linter` are documented false positives).
*   **Actionable Insights:**
    *   Applied a high-confidence minor fix to address the `seq_linter` warning. Replaced `1:ncol(top_sensors)` with the safer, idiomatic `seq_len(ncol(top_sensors))` at line 377 in `Updated_Seatek_Analysis.R`. This prevents potential `1:0` edge cases if the structure evaluates empty.
    *   Verified the fix via `lintr` and re-ran tests.
*   **Historical Check:** Did not locate any open "Jules Daily QA & Agentic Review" issues requiring duplicate status tracking.

**Commands Executed During Verification:**
```bash
# Python tests
python3 -m pytest tests/

# R linter
export RENV_CONFIG_SANDBOX_ENABLED=FALSE && Rscript -e "lintr::lint_dir('.')"

# R tests
export RENV_CONFIG_SANDBOX_ENABLED=FALSE && Rscript -e "source('tests/testthat/testthat.R'); testthat::test_dir('tests/testthat/')"
```

---
*PR created automatically by Jules for task [12523875904053772938](https://jules.google.com/task/12523875904053772938) started by @abhimehro*