### PR TITLE
⚡ Bolt: Optimize regex compilation in repository automation tasks

### DIFF
--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -723,10 +723,15 @@ def run_daily_status_report(config: dict[str, Any]) -> dict[str, Any]:
     )
 
 
+# ⚡ Bolt: Pre-compile regular expressions to prevent redundant pattern compilation
+# overhead on every invocation, particularly in loops over issues.
+STATUS_MARKER_PATTERN = re.compile(
+    r"<!-- repository-automation:task-status\n(.*?)\n-->", re.S
+)
+
+
 def extract_status_markers(issue_body: str) -> dict[str, str]:
-    match = re.search(
-        r"<!-- repository-automation:task-status\n(.*?)\n-->", issue_body, re.S
-    )
+    match = STATUS_MARKER_PATTERN.search(issue_body)
     if not match:
         return {}
     markers = {}


### PR DESCRIPTION
💡 What: Pre-compiled the `<!-- repository-automation:task-status\n(.*?)\n-->` regular expression into a module-level constant (`STATUS_MARKER_PATTERN`) rather than executing `re.search` with an inline string pattern inside `extract_status_markers()`.

🎯 Why: The `extract_status_markers()` function is called sequentially inside loops processing potentially hundreds of issue bodies (e.g. within `weekly_markers()`). Using `re.search` with an inline pattern forces Python to repeatedly retrieve the pattern from its internal compilation cache or recompile it entirely. Hoisting it explicitly eliminates this overhead entirely.

📊 Impact: Expected to slightly reduce the CPU overhead and execution time during large weekly retrospective or backlog scans by bypassing redundant regex cache lookups in tight loops.

🔬 Measurement: Review changes to `.github/scripts/repository_automation_tasks.py` to ensure `STATUS_MARKER_PATTERN.search(issue_body)` has replaced `re.search` while preserving the `re.S` dotall flag behavior. Run `PYTHONPATH=. python3 -m pytest tests/` to confirm functionality.

---
*PR created automatically by Jules for task [12327282332184765091](https://jules.google.com/task/12327282332184765091) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->