### PR TITLE
🛡️ Sentinel: [MEDIUM] Enforce absolute path resolution for system binaries

### DIFF
--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -28,7 +28,12 @@ def get_repo_info():
         if "PATH" in os.environ:
             env["PATH"] = os.environ["PATH"]
 
-        git_bin = shutil.which("git") or "git"
+        git_bin = shutil.which("git")
+        if not git_bin:
+            # SECURITY: Fail fast if executable not found instead of falling back to
+            # a partial path like "git" which is vulnerable to path hijacking.
+            logging.error("Git executable not found in PATH.")
+            return "unknown", "unknown", "unknown"
 
         # Get origin URL
         origin_url = subprocess.check_output(


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `get_repo_info` function in `code_health_scanner.py` fell back to using the raw string `"git"` if `shutil.which("git")` failed to find the executable. This relies on the environment's `PATH` resolving the executable during `subprocess.check_output`, making it a partial executable path.
🎯 Impact: This violates Bandit rule B607 and introduces a potential path hijacking vulnerability. If a malicious executable named `git` was dropped in the search path on an operating system like Windows, it could be executed instead of the intended system binary. Additionally, it could cause unhandled `FileNotFoundError` exceptions instead of safely degrading.
🔧 Fix: Modified the script to fail fast and securely log an error message if `shutil.which` returns `None`, completely removing the insecure `"git"` fallback.
✅ Verification: Ran `pylint code_health_scanner.py` (scored 10.00/10) and the test suite via `PYTHONPATH=. python3 -m pytest tests/` which passed successfully.

---
*PR created automatically by Jules for task [14825129902890606166](https://jules.google.com/task/14825129902890606166) started by @abhimehro*