### PR TITLE
Jules Daily QA & Agentic Review - Lint Fix

### DIFF
--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -159,7 +159,8 @@ execute_tasks_parallel <- function(tasks, task_func) {
 compute_sensor_metrics <- function(df, filename) {
   # OPTIMIZATION: which(x > 0) is natively faster at dropping NAs than
   # !is.na() &
-  # ⚡ Bolt: Replace regex grep with native startsWith for faster column name subsetting
+  # ⚡ Bolt: Replace regex grep with native startsWith for faster column
+  # name subsetting
   sensor_names <- names(df)[startsWith(names(df), "Sensor")]
 
   # ⚡ Bolt: Replace sapply with data.table native lapply(.SD) for O(1) row


### PR DESCRIPTION
### Jules Daily QA & Agentic Review Summary

**Verification:**
- Codebase built and ran without errors.
- All tests passed.
- Linter flagged one `line_length_linter` issue in `Updated_Seatek_Analysis.R`. This has been autofixed.

**Historical Check:**
- Confirmed no open issues or discussions for "Jules Daily QA & Agentic Review" exist.

**Actionable Insights:**
- Autofixed a long comment line in `Updated_Seatek_Analysis.R` that exceeded 80 characters.

**Commands Used:**
```bash
# Setup missing dependencies to run R properly in sandbox
sudo apt-get update && sudo apt-get install -y r-base libgit2-dev pandoc libcurl4-openssl-dev libxml2-dev libssl-dev libfontconfig1-dev libharfbuzz-dev libfribidi-dev libuv1-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev gh & wait

# Install testthat
export RENV_CONFIG_SANDBOX_ENABLED=FALSE && Rscript -e "options(repos=c(CRAN='https://packagemanager.posit.co/cran/__linux__/noble/latest')); if (!require('testthat', quietly=TRUE)) install.packages('testthat')"

# Install microbenchmark (missing for testing)
export RENV_CONFIG_SANDBOX_ENABLED=FALSE && Rscript -e "install.packages('microbenchmark', repos='https://packagemanager.posit.co/cran/__linux__/noble/latest')"

# Run tests
export RENV_CONFIG_SANDBOX_ENABLED=FALSE && Rscript -e "library(testthat); source('Updated_Seatek_Analysis.R'); test_dir('tests', reporter = 'summary')"

# Run lintr
export RENV_CONFIG_SANDBOX_ENABLED=FALSE && Rscript -e "if (!require('lintr', quietly = TRUE)) install.packages('lintr', repos='https://packagemanager.posit.co/cran/__linux__/noble/latest'); library(lintr); lint_dir('.', exclusions = list('renv/', 'backups/', 'Series_27/Analysis/venv/', 'implementation/', 'tests/'))"
```

**Closure:**
The repository is healthy. The single linter issue has been resolved in this PR.

---
*PR created automatically by Jules for task [5082508508513969629](https://jules.google.com/task/5082508508513969629) started by @abhimehro*