### PR TITLE
🧪 testing improvement: Add edge case tests for numeric_version

### DIFF
--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -54,3 +54,30 @@ def test_target_ref_skips_commit_pins() -> None:
     sha = "df4cb1c069e1874edd31b4311f1884172cec0e10"
     assert numeric_version(sha) is None
     assert target_ref(sha, "v6.0.4") is None
+
+
+def test_numeric_version_extracts_tuples_and_handles_edge_cases() -> None:
+    # Full versions
+    assert numeric_version("v1.2.3") == (1, 2, 3)
+    assert numeric_version("1.2.3") == (1, 2, 3)
+
+    # Partial versions (missing patch, missing minor)
+    assert numeric_version("v1.2") == (1, 2, 0)
+    assert numeric_version("v1") == (1, 0, 0)
+    assert numeric_version("4.5") == (4, 5, 0)
+    assert numeric_version("4") == (4, 0, 0)
+
+    # Versions with prefixes or suffixes
+    assert numeric_version("v2.0.0-rc.1") == (2, 0, 0)
+    assert numeric_version("v5.6.7-beta") == (5, 6, 7)
+    assert numeric_version("pkg-v3.4.5") == (3, 4, 5)
+
+    # Invalid formats
+    assert numeric_version("invalid") is None
+    assert numeric_version("v") is None
+    assert numeric_version("a.b.c") is None
+    assert numeric_version("") is None
+
+    # Commit SHA
+    sha = "df4cb1c069e1874edd31b4311f1884172cec0e10"
+    assert numeric_version(sha) is None


### PR DESCRIPTION
🎯 **What:** 
Added dedicated unit tests for the `numeric_version(text: str)` function in `repository_automation_common.py`, which was missing direct test coverage.

📊 **Coverage:**
The new tests cover the following scenarios:
*   **Full versions:** `v1.2.3`, `1.2.3`
*   **Partial versions:** Missing patch or minor versions (e.g. `v1.2`, `4`)
*   **Versions with prefixes/suffixes:** Correctly stripping extra metadata (e.g. `pkg-v3.4.5`, `v2.0.0-rc.1`)
*   **Invalid formats:** Invalid input yielding `None` (e.g. `invalid`, `v`, `a.b.c`, empty string)
*   **Commit SHAs:** Explicit tests verifying a 40-char SHA correctly returns `None`

✨ **Result:**
The `numeric_version` function is now fully tested across expected happy paths and various failure conditions, improving safety during future refactors or updates to the matching regular expressions.

---
*PR created automatically by Jules for task [11654373292149569271](https://jules.google.com/task/11654373292149569271) started by @abhimehro*