### PR TITLE
🧪 Add test for read_file_safe with restricted permissions

### DIFF
--- a/tests/test_code_health_scanner.py
+++ b/tests/test_code_health_scanner.py
@@ -99,3 +99,17 @@ def test_read_file_safe_null_byte():
     # Attempting to read a file with an embedded null character should return empty list
     # and not raise a ValueError (ValueError: lstat: embedded null character in path)
     assert read_file_safe("test\0.txt") == []
+
+def test_read_file_safe_restricted_permissions():
+    test_file = "test_restricted.txt"
+    with open(test_file, "w") as f:
+        f.write("test content")
+    try:
+        # Remove read permissions
+        os.chmod(test_file, 0o000)
+        assert read_file_safe(test_file) == []
+    finally:
+        # Restore permissions so it can be deleted
+        if os.path.exists(test_file):
+            os.chmod(test_file, 0o644)
+            os.remove(test_file)


### PR DESCRIPTION
🎯 **What:** Added a missing error test case for `read_file_safe` in `code_health_scanner.py` to verify it properly catches `OSError` when trying to read files lacking read permissions.
📊 **Coverage:** The `OSError` branch in the `except` block of `read_file_safe` is now explicitly covered.
✨ **Result:** Increased test coverage and confidence that the codebase fails securely and cleanly when encountering permission errors on local filesystem access.

---
*PR created automatically by Jules for task [12303115647361689608](https://jules.google.com/task/12303115647361689608) started by @abhimehro*