### PR TITLE
🔒 Security: Fix credential exfiltration risk by moving to environment variable allowlist

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -136,11 +136,7 @@ def run_process(
     )
 
 
-def run_shell_command(
-    command: str | list[str],
-    timeout: int = 1800,
-    custom_env: dict[str, str] | None = None,
-) -> dict[str, Any]:
+def _prepare_safe_env(custom_env: dict[str, str] | None) -> dict[str, str]:
     safe_env = command_env()
     if custom_env:
         safe_env.update(custom_env)
@@ -152,17 +148,27 @@ def run_shell_command(
         for k, v in safe_env.items()
         if k in SAFE_ENV_VARS or k.startswith("GITHUB_")
     }
+
     if "PATH" not in filtered_env and "PATH" in safe_env:
         filtered_env["PATH"] = safe_env["PATH"]
 
-    safe_env = filtered_env
     if custom_env:
-        safe_env.update(custom_env)
+        filtered_env.update(custom_env)
 
     # Defense in depth: strictly remove known high-value tokens even if passed in custom_env
     # or caught by the GITHUB_ prefix.
-    for token in ["GH_TOKEN", "GITHUB_TOKEN"]:
-        safe_env.pop(token, None)
+    filtered_env.pop("GH_TOKEN", None)
+    filtered_env.pop("GITHUB_TOKEN", None)
+
+    return filtered_env
+
+
+def run_shell_command(
+    command: str | list[str],
+    timeout: int = 1800,
+    custom_env: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    safe_env = _prepare_safe_env(custom_env)
 
     # Allow backward compatibility for existing command string configurations while we migrate,
     # but the primary path relies on lists of arguments to avoid shell injection.

--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -37,6 +37,39 @@ ALLOWED_STATUSES = {"success", "warning", "failure", "needs_review", "skipped"}
 # SECURITY: Define an explicit allowlist of safe environment variables for subprocess execution.
 # This prevents credential exfiltration (e.g., AWS_ACCESS_KEY_ID, NPM_TOKEN) while allowing
 # standard CI and system functionality.
+
+
+def filter_env_securely(
+    base_env: dict[str, str], custom_env: dict[str, str] | None = None
+) -> dict[str, str]:
+    """
+    Applies the SAFE_ENV_VARS allowlist to the environment to prevent credential exfiltration.
+    Preserves explicitly provided custom_env variables, but strictly removes high-value tokens.
+    """
+    env = base_env.copy()
+    if custom_env:
+        env.update(custom_env)
+
+    # Apply allowlist
+    filtered_env = {
+        k: v for k, v in env.items() if k in SAFE_ENV_VARS or k.startswith("GITHUB_")
+    }
+
+    # Ensure PATH survives
+    if "PATH" not in filtered_env and "PATH" in env:
+        filtered_env["PATH"] = env["PATH"]
+
+    # Re-apply custom overrides that might have been filtered out
+    if custom_env:
+        filtered_env.update(custom_env)
+
+    # Strict defense in depth removal
+    for token in ["GH_TOKEN", "GITHUB_TOKEN"]:
+        filtered_env.pop(token, None)
+
+    return filtered_env
+
+
 SAFE_ENV_VARS = {
     "PATH",
     "HOME",
@@ -108,20 +141,10 @@ def run_process(
     # SECURITY: Use an explicit allowlist to prevent credential exfiltration.
     # Third-party dependencies may attempt to scrape the environment for secrets.
     if command[0] != GH_BIN:
-        proc_env = {
-            k: v
-            for k, v in proc_env.items()
-            if k in SAFE_ENV_VARS or k.startswith("GITHUB_")
-        }
-        # Defense in depth: strictly remove known high-value tokens even if passed in custom_env
-        # or caught by the GITHUB_ prefix.
-        for token in ["GH_TOKEN", "GITHUB_TOKEN"]:
-            proc_env.pop(token, None)
-        # Ensure PATH is always present even if stripped, to avoid breaking basic commands
-        if "PATH" not in proc_env and "PATH" in (
-            env if env is not None else os.environ
-        ):
-            proc_env["PATH"] = (env if env is not None else os.environ).get("PATH", "")
+        fallback_env = env if env is not None else os.environ
+        if "PATH" not in proc_env and "PATH" in fallback_env:
+            proc_env["PATH"] = fallback_env.get("PATH", "")
+        proc_env = filter_env_securely(proc_env)
 
     return subprocess.run(
         command,
@@ -136,39 +159,12 @@ def run_process(
     )
 
 
-def _prepare_safe_env(custom_env: dict[str, str] | None) -> dict[str, str]:
-    safe_env = command_env()
-    if custom_env:
-        safe_env.update(custom_env)
-
-    # SECURITY: Apply allowlist to enforce least privilege, while preserving explicitly
-    # provided custom_env configurations for intentional overrides.
-    filtered_env = {
-        k: v
-        for k, v in safe_env.items()
-        if k in SAFE_ENV_VARS or k.startswith("GITHUB_")
-    }
-
-    if "PATH" not in filtered_env and "PATH" in safe_env:
-        filtered_env["PATH"] = safe_env["PATH"]
-
-    if custom_env:
-        filtered_env.update(custom_env)
-
-    # Defense in depth: strictly remove known high-value tokens even if passed in custom_env
-    # or caught by the GITHUB_ prefix.
-    filtered_env.pop("GH_TOKEN", None)
-    filtered_env.pop("GITHUB_TOKEN", None)
-
-    return filtered_env
-
-
 def run_shell_command(
     command: str | list[str],
     timeout: int = 1800,
     custom_env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    safe_env = _prepare_safe_env(custom_env)
+    safe_env = filter_env_securely(command_env(), custom_env)
 
     # Allow backward compatibility for existing command string configurations while we migrate,
     # but the primary path relies on lists of arguments to avoid shell injection.

--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -34,6 +34,38 @@ if not GIT_BIN:
 
 ALLOWED_STATUSES = {"success", "warning", "failure", "needs_review", "skipped"}
 
+# SECURITY: Define an explicit allowlist of safe environment variables for subprocess execution.
+# This prevents credential exfiltration (e.g., AWS_ACCESS_KEY_ID, NPM_TOKEN) while allowing
+# standard CI and system functionality.
+SAFE_ENV_VARS = {
+    "PATH",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+    "TERM",
+    "LANG",
+    "LC_ALL",
+    "GITHUB_WORKSPACE",
+    "GITHUB_REPOSITORY",
+    "GITHUB_SHA",
+    "GITHUB_REF",
+    "GITHUB_ACTOR",
+    "GITHUB_API_URL",
+    "GITHUB_SERVER_URL",
+    "GITHUB_GRAPHQL_URL",
+    "GITHUB_RUN_ID",
+    "GITHUB_RUN_NUMBER",
+    "GITHUB_RUN_ATTEMPT",
+    "GITHUB_ACTION",
+    "RUNNER_OS",
+    "RUNNER_ARCH",
+    "RUNNER_NAME",
+    "RUNNER_TEMP",
+    "RUNNER_TOOL_CACHE",
+    "CI",
+}
+
 
 def command_env() -> dict[str, str]:
     return {**os.environ, "GH_PAGER": "cat"}
@@ -73,13 +105,23 @@ def run_process(
     env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     proc_env = env if env is not None else command_env()
-    # SECURITY: Strip sensitive tokens to enforce least privilege and prevent credential
-    # exfiltration by potentially compromised third-party dependencies.
-    # While a strict allowlist is ideal, it breaks CI functionality (e.g. stripping HOME, GITHUB_WORKSPACE).
+    # SECURITY: Use an explicit allowlist to prevent credential exfiltration.
+    # Third-party dependencies may attempt to scrape the environment for secrets.
     if command[0] != GH_BIN:
-        proc_env = proc_env.copy()
+        proc_env = {
+            k: v
+            for k, v in proc_env.items()
+            if k in SAFE_ENV_VARS or k.startswith("GITHUB_")
+        }
+        # Defense in depth: strictly remove known high-value tokens even if passed in custom_env
+        # or caught by the GITHUB_ prefix.
         for token in ["GH_TOKEN", "GITHUB_TOKEN"]:
             proc_env.pop(token, None)
+        # Ensure PATH is always present even if stripped, to avoid breaking basic commands
+        if "PATH" not in proc_env and "PATH" in (
+            env if env is not None else os.environ
+        ):
+            proc_env["PATH"] = (env if env is not None else os.environ).get("PATH", "")
 
     return subprocess.run(
         command,
@@ -94,14 +136,31 @@ def run_process(
     )
 
 
-def run_shell_command(command: str | list[str], timeout: int = 1800, custom_env: dict[str, str] | None = None) -> dict[str, Any]:
+def run_shell_command(
+    command: str | list[str],
+    timeout: int = 1800,
+    custom_env: dict[str, str] | None = None,
+) -> dict[str, Any]:
     safe_env = command_env()
     if custom_env:
         safe_env.update(custom_env)
 
-    # SECURITY: Strip sensitive tokens to enforce least privilege and prevent credential
-    # exfiltration by potentially compromised third-party dependencies executed in the shell.
-    # While a strict allowlist is ideal, it breaks CI functionality (e.g. stripping HOME, GITHUB_WORKSPACE).
+    # SECURITY: Apply allowlist to enforce least privilege, while preserving explicitly
+    # provided custom_env configurations for intentional overrides.
+    filtered_env = {
+        k: v
+        for k, v in safe_env.items()
+        if k in SAFE_ENV_VARS or k.startswith("GITHUB_")
+    }
+    if "PATH" not in filtered_env and "PATH" in safe_env:
+        filtered_env["PATH"] = safe_env["PATH"]
+
+    safe_env = filtered_env
+    if custom_env:
+        safe_env.update(custom_env)
+
+    # Defense in depth: strictly remove known high-value tokens even if passed in custom_env
+    # or caught by the GITHUB_ prefix.
     for token in ["GH_TOKEN", "GITHUB_TOKEN"]:
         safe_env.pop(token, None)
 

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -3,7 +3,9 @@ from unittest.mock import patch, MagicMock
 import sys
 import os
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../.github/scripts')))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.github/scripts"))
+)
 from repository_automation_common import (
     BASH_BIN,
     is_commit_sha,
@@ -12,7 +14,8 @@ from repository_automation_common import (
     target_ref,
 )
 
-@patch('repository_automation_common.run_process')
+
+@patch("repository_automation_common.run_process")
 def test_run_shell_command_string(mock_run_process):
     mock_proc = MagicMock()
     mock_proc.returncode = 0
@@ -28,7 +31,8 @@ def test_run_shell_command_string(mock_run_process):
     assert args == [BASH_BIN, "-c", "echo hello"]
     assert result["exit_code"] == 0
 
-@patch('repository_automation_common.run_process')
+
+@patch("repository_automation_common.run_process")
 def test_run_shell_command_list(mock_run_process):
     mock_proc = MagicMock()
     mock_proc.returncode = 0
@@ -54,3 +58,70 @@ def test_target_ref_skips_commit_pins() -> None:
     sha = "df4cb1c069e1874edd31b4311f1884172cec0e10"
     assert numeric_version(sha) is None
     assert target_ref(sha, "v6.0.4") is None
+
+
+@patch("repository_automation_common.subprocess.run")
+def test_run_process_allowlist(mock_run):
+    mock_proc = MagicMock()
+    mock_proc.returncode = 0
+    mock_proc.stdout = "output"
+    mock_proc.stderr = ""
+    mock_run.return_value = mock_proc
+
+    from repository_automation_common import run_process
+
+    # Test that standard env vars are kept and sensitive ones are stripped
+    test_env = {
+        "PATH": "/usr/bin",
+        "HOME": "/home/user",
+        "AWS_ACCESS_KEY_ID": "sensitive1",
+        "NPM_TOKEN": "sensitive2",
+        "GH_TOKEN": "sensitive3",
+        "GITHUB_TOKEN": "sensitive4",
+        "GITHUB_WORKSPACE": "/workspace",
+    }
+
+    run_process(["echo", "hello"], env=test_env)
+
+    mock_run.assert_called_once()
+    passed_env = mock_run.call_args[1].get("env", {})
+
+    # Check safe vars
+    assert passed_env.get("PATH") == "/usr/bin"
+    assert passed_env.get("HOME") == "/home/user"
+    assert passed_env.get("GITHUB_WORKSPACE") == "/workspace"
+
+    # Check sensitive vars are stripped
+    assert "AWS_ACCESS_KEY_ID" not in passed_env
+    assert "NPM_TOKEN" not in passed_env
+    assert "GH_TOKEN" not in passed_env
+    assert "GITHUB_TOKEN" not in passed_env
+
+
+@patch("repository_automation_common.run_process")
+def test_run_shell_command_allowlist_and_custom(mock_run_process):
+    mock_proc = MagicMock()
+    mock_proc.returncode = 0
+    mock_proc.stdout = "output"
+    mock_proc.stderr = ""
+    mock_run_process.return_value = mock_proc
+
+    # Ensure os.environ has some sensitive stuff for the default safe_env grab
+    with patch.dict(os.environ, {"AWS_ACCESS_KEY_ID": "sensitive1", "PATH": "/bin"}):
+        result = run_shell_command(
+            "echo hello",
+            custom_env={"MY_VAR": "custom_val", "GH_TOKEN": "should_be_stripped"},
+        )
+
+        mock_run_process.assert_called_once()
+        passed_env = mock_run_process.call_args[1].get("env", {})
+
+        # Check that os.environ sensitive is stripped by command_env -> allowlist logic
+        assert "AWS_ACCESS_KEY_ID" not in passed_env
+        assert passed_env.get("PATH") == "/bin"
+
+        # Check custom_env is respected
+        assert passed_env.get("MY_VAR") == "custom_val"
+
+        # Check GH_TOKEN explicitly stripped even if in custom_env
+        assert "GH_TOKEN" not in passed_env


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is an incomplete token scrubbing in the subprocess execution environment. The previous code used a hardcoded denylist (just removing `GH_TOKEN` and `GITHUB_TOKEN`), leaving the environment vulnerable to other sensitive tokens (like `AWS_ACCESS_KEY_ID` or `NPM_TOKEN`) leaking to third-party dependencies during subprocess execution. 

⚠️ **Risk:** The potential impact if left unfixed is credential exfiltration. Any third-party dependency executed via subprocess could potentially scrape the environment variables and exfiltrate sensitive unlisted credentials, leading to broader environment or cloud account compromise.

🛡️ **Solution:** The solution shifted from a denylist approach to a strict allowlist (`SAFE_ENV_VARS`). Now, only standard, safe CI and system variables (e.g., `PATH`, `HOME`, `GITHUB_WORKSPACE`) are passed down to the subprocess. Additionally, to preserve internal tool usability, custom environments passed to `run_shell_command` are honored but continue to strictly filter known high-value tokens (`GH_TOKEN` / `GITHUB_TOKEN`) as a defense-in-depth measure. Unit tests were added to ensure the correct handling of `custom_env` and the allowlist.

---
*PR created automatically by Jules for task [6588870481756984360](https://jules.google.com/task/6588870481756984360) started by @abhimehro*