### PR TITLE
🧪 Add equivalence tests for sapply vs lapply optimization

### DIFF
--- a/tests/testthat/test-sapply_vs_lapply_equivalence.R
+++ b/tests/testthat/test-sapply_vs_lapply_equivalence.R
@@ -1,0 +1,57 @@
+test_that("lapply(.SD) optimization produces exact same results as sapply baseline", {
+  library(data.table)
+
+  # Function to clean values (dropping NAs and values <= 0)
+  # This matches the implementation in the benchmark and main script
+  clean_vals <- function(x) x[which(x > 0)]
+
+  # Setup synthetic data.table mimicking the benchmark data
+  set.seed(42)
+  n_rows <- 50
+  n_cols <- 5
+  sensor_names <- paste0("Sensor", sprintf("%02d", 1:n_cols))
+
+  # Introduce some NAs and negatives to simulate real-world data and edge cases
+  # Done on the matrix before converting to data.table to ensure correct element-wise replacement
+  mat <- matrix(runif(n_rows * n_cols, -5, 15), nrow = n_rows)
+  mat[sample(1:(n_rows * n_cols), 20)] <- NA
+  mat[sample(1:(n_rows * n_cols), 20)] <- -1
+
+  df <- data.table(mat)
+  setnames(df, sensor_names)
+
+  # --- Baseline: Using sapply with column slicing ---
+  baseline_first10 <- sapply(df[, ..sensor_names], function(x) {
+    mean(clean_vals(head(x, 10)))
+  })
+  baseline_last5   <- sapply(df[, ..sensor_names], function(x) {
+    mean(clean_vals(tail(x, 5)))
+  })
+  baseline_full    <- sapply(df[, ..sensor_names], function(x) {
+    mean(clean_vals(x))
+  })
+
+  # --- Optimized: Using data.table native lapply(.SD) ---
+  optimized_first10 <- unlist(df[1:min(10, .N), lapply(.SD, function(x) {
+    mean(clean_vals(x))
+  }), .SDcols = sensor_names])
+
+  optimized_last5   <- unlist(df[max(1, .N - 4):.N, lapply(.SD, function(x) {
+    mean(clean_vals(x))
+  }), .SDcols = sensor_names])
+
+  optimized_full    <- unlist(df[, lapply(.SD, function(x) {
+    mean(clean_vals(x))
+  }), .SDcols = sensor_names])
+
+  # --- Assertions ---
+  # Names should match
+  expect_equal(names(baseline_first10), names(optimized_first10))
+  expect_equal(names(baseline_last5), names(optimized_last5))
+  expect_equal(names(baseline_full), names(optimized_full))
+
+  # Values should be identical
+  expect_equal(baseline_first10, optimized_first10)
+  expect_equal(baseline_last5, optimized_last5)
+  expect_equal(baseline_full, optimized_full)
+})


### PR DESCRIPTION
🎯 **What:** Added missing unit test coverage to functionally verify the optimization presented in `test_perf_sapply_vs_lapply.R`.

📊 **Coverage:** A new test suite (`tests/testthat/test-sapply_vs_lapply_equivalence.R`) now evaluates both the baseline `sapply` method and the optimized `data.table::lapply(.SD)` method on a synthesized `data.table` featuring missing values (`NA`) and negatives (`-1`). It rigorously asserts that both implementation paths yield the exact same numeric outcomes and column names for the 'first 10', 'last 5', and 'full' aggregate operations.

✨ **Result:** Enhanced test coverage provides structural assurance that the faster `lapply(.SD)` optimization mathematically mirrors the slower baseline computation, making future scaling or refactoring safe.

═════ ELIR ═════
PURPOSE: Functionally verifies that the faster lapply(.SD) approach computes exactly the same results as the slower sapply baseline benchmark.
SECURITY: No direct impact; maintains calculation integrity.
FAILS IF: The clean_vals logic changes or data.table sub-setting behaves differently in future R versions.
VERIFY: Run the test suite to ensure the expect_equal assertions pass.
MAINTAIN: Keep this equivalence test updated if the core aggregation logic in the main Seatek_Analysis script is modified.

---
*PR created automatically by Jules for task [10522981342607944284](https://jules.google.com/task/10522981342607944284) started by @abhimehro*