### PR TITLE
🛡️ Sentinel: [security improvement] explicitly disable shell in subprocess.run for tests

### DIFF
--- a/tests/test_refactoring_agent_workflow.py
+++ b/tests/test_refactoring_agent_workflow.py
@@ -71,6 +71,7 @@ def test_prepare_command_extracts_first_cs_agent_line_from_multiline_comment(tmp
         [bash, "-e", "-c", prepare_command_step["run"]],
         check=False,
         capture_output=True,
+        shell=False,
         text=True,
         env={
             "PATH": os.environ.get("PATH", ""),
@@ -110,6 +111,7 @@ def test_prepare_command_fails_when_no_cs_agent_line_present(tmp_path):
         [bash, "-e", "-c", prepare_command_step["run"]],
         check=False,
         capture_output=True,
+        shell=False,
         text=True,
         env={
             "PATH": os.environ.get("PATH", ""),


### PR DESCRIPTION
🚨 **Severity:** Low
💡 **Vulnerability:** `tests/test_refactoring_agent_workflow.py` used `subprocess.run` with a list of arguments without explicitly defining `shell=False`.
🎯 **Impact:** While `shell=False` is the default behavior in Python, implicitly relying on the default leaves the code vulnerable to accidental modifications (e.g., a developer explicitly setting `shell=True` to run a complex command without realizing the security implications) and fails static analysis checks (like Bandit).
🔧 **Fix:** Explicitly set `shell=False` for the `subprocess.run` calls to satisfy SAST tools and clearly communicate the security intent.
✅ **Verification:** Verified by running the test suite (`PYTHONPATH=. python3 -m pytest tests/`), ensuring no regressions were introduced. All tests passed.

═════ ELIR ═════
PURPOSE: This PR hardens `tests/test_refactoring_agent_workflow.py` by explicitly disabling the shell in `subprocess.run` calls.
SECURITY: Explicitly setting `shell=False` prevents accidental shell injection vulnerabilities during future modifications and satisfies SAST tools.
FAILS IF: Tests using `subprocess.run` unexpectedly start requiring shell features (like pipes or redirects) and fail.
VERIFY: Confirm the tests still pass successfully.
MAINTAIN: Ensure any new `subprocess` calls in tests or scripts explicitly define `shell=False`.

---
*PR created automatically by Jules for task [9367503559026912084](https://jules.google.com/task/9367503559026912084) started by @abhimehro*