### PR TITLE
🧪 Add tests for validate_sensor_file

### DIFF
--- a/tests/testthat/test-validate_sensor_file.R
+++ b/tests/testthat/test-validate_sensor_file.R
@@ -1,0 +1,47 @@
+library(testthat)
+
+# The validate_sensor_file function is expected to be in the global environment
+# as Updated_Seatek_Analysis.R is sourced by the testthat.R helper.
+
+test_that("validate_sensor_file accepts valid files", {
+  # Create a valid temporary file
+  valid_file <- tempfile(fileext = ".txt")
+  writeLines("test data", valid_file)
+  on.exit(unlink(valid_file, force = TRUE))
+
+  # Should not error
+  expect_silent(validate_sensor_file(valid_file))
+})
+
+test_that("validate_sensor_file errors on non-existent file", {
+  non_existent_file <- tempfile(fileext = ".txt")
+  expect_error(validate_sensor_file(non_existent_file), "Invalid file:")
+})
+
+test_that("validate_sensor_file errors on wrong extension", {
+  # Create a file with a wrong extension
+  wrong_ext_file <- tempfile(fileext = ".csv")
+  writeLines("test data", wrong_ext_file)
+  on.exit(unlink(wrong_ext_file, force = TRUE))
+
+  expect_error(validate_sensor_file(wrong_ext_file), "Invalid file:")
+})
+
+test_that("validate_sensor_file errors on oversized file", {
+  # Create a valid temporary file
+  large_file <- tempfile(fileext = ".txt")
+  writeLines("test data", large_file)
+  on.exit(unlink(large_file, force = TRUE))
+
+  # Temporarily override file.size in the global environment to simulate a large file
+  original_file_size <- base::file.size
+  assign("file.size", function(...) 60 * 1024 * 1024, envir = .GlobalEnv)
+
+  # Ensure cleanup of the mock
+  on.exit({
+    rm(list = "file.size", envir = .GlobalEnv)
+    unlink(large_file, force = TRUE)
+  }, add = TRUE)
+
+  expect_error(validate_sensor_file(large_file), "exceeds maximum allowed size")
+})


### PR DESCRIPTION
🎯 **What:** The `validate_sensor_file` function in `Updated_Seatek_Analysis.R` was lacking test coverage. It validates existence, extension, and file size (under 50MB) of sensor data files.
📊 **Coverage:** Added tests for the happy path (valid, small `.txt` file), non-existent files, files with the wrong extension, and oversized files. Oversized files were simulated by mocking `file.size` in the `.GlobalEnv` to avoid creating large dummy artifacts.
✨ **Result:** Improved test coverage for `validate_sensor_file` providing a strong safety net for any future refactoring involving file validation checks.

═════ ELIR ═════
PURPOSE: The `validate_sensor_file` function checks incoming sensor data files against conditions for extension and file size; this patch adds tests covering all its branches.
SECURITY: Testing file size validation confirms protection against basic resource exhaustion (OOM) via overly large files.
FAILS IF: The tests fail if base R functionalities or expected error message structures change.
VERIFY: Ensure test suite passes successfully.
MAINTAIN: The tests mock `file.size` in the `.GlobalEnv` to simulate large files without disk footprint; if refactoring, ensure cleanup `on.exit` behaves securely.

---
*PR created automatically by Jules for task [12556442571941934050](https://jules.google.com/task/12556442571941934050) started by @abhimehro*