### PR TITLE
🔒 Fix: Suppress false-positive Bandit warnings on safe subprocess calls

### DIFF
--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 import shutil
-import subprocess
+import subprocess  # nosec B404
 
 
 # Pre-compile the regex pattern for parsing git origin URLs.
@@ -36,7 +36,7 @@ def get_repo_info():
             return "unknown", "unknown", "unknown"
 
         # Get origin URL
-        origin_url = subprocess.check_output(
+        origin_url = subprocess.check_output(  # nosec B603
             [git_bin, "remote", "get-url", "origin"],
             stderr=subprocess.DEVNULL,
             env=env,
@@ -52,7 +52,7 @@ def get_repo_info():
         account, project = match.groups()
 
         # Get current commit hash
-        commit_hash = subprocess.check_output(
+        commit_hash = subprocess.check_output(  # nosec B603
             [git_bin, "rev-parse", "HEAD"],
             stderr=subprocess.DEVNULL,
             env=env,


### PR DESCRIPTION
🎯 **What:** Appended `# nosec B404` and `# nosec B603` to safe `subprocess` imports and calls in `code_health_scanner.py`.

⚠️ **Risk:** The code correctly uses `shutil.which('git')` to safely resolve the executable path, preventing path hijacking. However, SAST tools like Bandit flag any use of `subprocess.check_output` with `shell=False` without explicit suppression, causing false-positive CI pipeline failures.

🛡️ **Solution:** Explicitly suppress the warnings via inline comments (`# nosec B404` for the import and `# nosec B603` for the executions), satisfying the static analysis tool while maintaining the secure behavior. Validated locally using `bandit`.

---
*PR created automatically by Jules for task [9597196314694801627](https://jules.google.com/task/9597196314694801627) started by @abhimehro*