### PR TITLE
🧹 [code health improvement] Remove commented out library imports in tests

### DIFF
--- a/tests/testthat/test-dump_summary_excel.R
+++ b/tests/testthat/test-dump_summary_excel.R
@@ -3,10 +3,6 @@ library(testthat)
 # It's a dependency of Updated_Seatek_Analysis.R, so it should be loaded
 # if tests are run after sourcing the main script.
 # An explicit library call can be a safeguard if running tests in isolation.
-# library(openxlsx)
-# library(tools) # for file_path_sans_ext
-# library(utils) # for read.csv
-# library(stats) # for setNames
 
 # The dump_summary_excel function is expected to be in the global environment
 # as Updated_Seatek_Analysis.R should be sourced by the testthat.R helper.

--- a/tests/testthat/test-process_all_data.R
+++ b/tests/testthat/test-process_all_data.R
@@ -1,6 +1,5 @@
 library(testthat)
 library(data.table) # process_all_data likely uses data.table indirectly via read_sensor_data
-# library(openxlsx) # process_all_data uses openxlsx for writing, ensure it's noted if tests require it explicitly
 
 # The process_all_data function is expected to be in the global environment
 # as Updated_Seatek_Analysis.R should be sourced by the testthat.R helper.


### PR DESCRIPTION
🎯 **What:** Removed commented out `library(openxlsx)` and other related commented-out library imports in `tests/testthat/test-process_all_data.R` and `tests/testthat/test-dump_summary_excel.R`.

💡 **Why:** Dead, commented-out code clutters the test files and can cause confusion about whether a dependency is actually required. Removing these cleans up the codebase and improves readability.

✅ **Verification:** Verified by executing the full R `testthat` suite. All tests ran and passed successfully without the commented-out imports.

✨ **Result:** A cleaner, more readable test suite with no dead commented-out library imports.

═════ ELIR ═════
PURPOSE: Removed commented-out library imports from R test files to clean up dead code.
SECURITY: No security impact; removing dead code.
FAILS IF: A test was secretly relying on a library that was incorrectly commented out, but full test run confirms this is not the case.
VERIFY: Check that `testthat` tests still pass cleanly.
MAINTAIN: Ensure future test dependencies are explicitly imported and used, rather than commented out.

---
*PR created automatically by Jules for task [5352570428615776681](https://jules.google.com/task/5352570428615776681) started by @abhimehro*