### PR TITLE
🔒 Fix path traversal bypass in tar extraction

### DIFF
--- a/implementation/scripts/02_backup_system.R
+++ b/implementation/scripts/02_backup_system.R
@@ -52,12 +52,14 @@ restore_backup <- function(backup_file, restore_dir = getwd()) {
     # SECURITY: Verify contents for path traversal vulnerabilities before extraction
     contents <- utils::untar(backup_file, list = TRUE)
     # Reject:
-    # - POSIX absolute paths starting with '/'
+    # - POSIX absolute paths starting with '/' or '~'
     # - Windows drive-letter absolute paths like 'C:\...' or 'D:/...'
     # - UNC paths like '\\server\share\...'
     # - Any '..' traversal using either '/' or '\' as a separator
-    pattern <- "^(?:/|[A-Za-z]:[\\\\/]|\\\\\\\\)|(^|[\\\\/])\\.\\.(?:[\\\\/]|$)"
-    if (any(grepl(pattern, contents, perl = TRUE))) {
+    # Note: Whitespace is trimmed before evaluation to prevent anchor bypass.
+    contents_trimmed <- trimws(contents, which = "left")
+    pattern <- "^(?:/|\\\\\\\\|[A-Za-z]:|~)|(?:^|[\\\\/])\\.\\.(?:[\\\\/]|$)"
+    if (any(grepl(pattern, contents_trimmed, perl = TRUE))) {
       stop("Security Error: Backup archive contains absolute paths or path traversal patterns.")
     }
 


### PR DESCRIPTION
🎯 **What:** The previous regex used to validate archive contents before extraction could be bypassed by malicious files with leading whitespace (e.g., ` /etc/passwd`) or tilde expansion (e.g., `~/.ssh/id_rsa`).
⚠️ **Risk:** An attacker could craft a malicious tar archive that extracts files outside the designated `restore_dir`, potentially overwriting critical system files or extracting sensitive data.
🛡️ **Solution:** The validation logic was updated to:
1. Trim leading whitespace from filenames before validation to prevent anchor bypass.
2. Update the regular expression to explicitly block paths starting with `~` and correctly handle edge cases with Windows drive-relative paths.

═════ ELIR ═════
PURPOSE: Prevent malicious tar archives from extracting files to arbitrary file system locations by validating path structures.
SECURITY: Catches path traversal (..) and absolute paths (/, C:\, \\, ~) while preventing whitespace padding bypasses.
FAILS IF: An archive contains a complex, unhandled traversal path format that evades regex and standard path canonicalization.
VERIFY: Leading whitespace is trimmed correctly, and valid paths without traversal characters are successfully extracted.
MAINTAIN: When adding new supported OS environments, ensure the regex covers any new absolute path conventions.

---
*PR created automatically by Jules for task [4552057627152572017](https://jules.google.com/task/4552057627152572017) started by @abhimehro*