### PR TITLE
🧹 [code health improvement] Remove commented-out library imports in tests

### DIFF
--- a/tests/testthat/test-dump_summary_excel.R
+++ b/tests/testthat/test-dump_summary_excel.R
@@ -1,13 +1,4 @@
 library(testthat)
-# Ensure openxlsx is available for reading/writing Excel files.
-# It's a dependency of Updated_Seatek_Analysis.R, so it should be loaded
-# if tests are run after sourcing the main script.
-# An explicit library call can be a safeguard if running tests in isolation.
-# library(openxlsx)
-# library(tools) # for file_path_sans_ext
-# library(utils) # for read.csv
-# library(stats) # for setNames
-
 # The dump_summary_excel function is expected to be in the global environment
 # as Updated_Seatek_Analysis.R should be sourced by the testthat.R helper.
 


### PR DESCRIPTION
🎯 **What:** Removed a block of commented-out `library()` calls and their associated explanatory comments from `tests/testthat/test-dump_summary_excel.R`.
💡 **Why:** This was dead code left over from earlier development or debugging. Removing it improves the maintainability and readability of the test file by reducing clutter.
✅ **Verification:** Ran the full R test suite using `testthat` to confirm that no required dependencies were missing and that all tests still pass successfully.
✨ **Result:** A cleaner, more readable test file without unnecessary commented-out code.

---
*PR created automatically by Jules for task [7722452747428040726](https://jules.google.com/task/7722452747428040726) started by @abhimehro*