### PR TITLE
🧪 Add missing tryCatch error test for fread in read_sensor_data

### DIFF
--- a/tests/testthat/test-read_sensor_data.R
+++ b/tests/testthat/test-read_sensor_data.R
@@ -105,3 +105,23 @@ test_that("read_sensor_data enforces the 50MB maximum file size limit", {
     fixed = TRUE
   )
 })
+
+test_that("fread error is caught in read_sensor_data", {
+  test_file <- tempfile(fileext = ".txt")
+  writeLines("test data", test_file)
+
+  # Make the file unreadable to trigger an fread error
+  Sys.chmod(test_file, "000")
+
+  # Ensure file is cleaned up and permissions restored so tempfile can delete it
+  on.exit({
+    Sys.chmod(test_file, "644")
+    suppressWarnings(file.remove(test_file))
+  }, add = TRUE)
+
+  expect_error(
+    read_sensor_data(test_file),
+    "Error reading.*cannot open",
+    ignore.case = TRUE
+  )
+})


### PR DESCRIPTION
🎯 What: The test suite was missing a test to verify the tryCatch block around data.table::fread inside the read_sensor_data function.
  📊 Coverage: The new test covers the specific error handling path when fread fails due to file permission/read errors.
  ✨ Result: Improved reliability of the read_sensor_data function by ensuring it properly catches and re-throws errors with custom messages when file reading fails.

---
*PR created automatically by Jules for task [15469760805248905317](https://jules.google.com/task/15469760805248905317) started by @abhimehro*