### PR TITLE
Draft: Salvage #476 rollmean3 tail optimization

### DIFF
--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -333,7 +333,7 @@ calculate_summary_stats <- function(results) {
         min       = min(v_val),
         max       = max(v_val),
         count     = n,
-        rollmean3 = if (n < 3) NA_real_ else mean(tail(v_val, 3))
+        rollmean3 = if (n < 3) NA_real_ else sum(v_val[(n - 2):n]) / 3
       )
     }
   }


### PR DESCRIPTION
## ELIR
- Evidence: Salvages the unique rollmean3 trailing-window optimization from #476 onto current main.
- Lineage: Supersedes #476; journal changes were intentionally skipped.
- Implementation: Replaced mean(tail(v_val, 3)) with direct indexing and sum for the last three non-missing values.
- Risk: Low; arithmetic is equivalent for n >= 3 and preserves NA behavior for shorter vectors.

## Verification
- Rscript -e "parse('Updated_Seatek_Analysis.R')" — passed.
