### PR TITLE
⚡ Bolt: Optimize tail() usage with direct vector indexing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -97,3 +97,6 @@
 ## 2025-02-23 - Avoid redundant datetime operations in comprehensions
 **Learning:** Calling functions that query the current time (`now_utc()`) and perform date math inside large list comprehensions adds significant constant-factor overhead.
 **Action:** Pre-calculate absolute datetime cutoffs outside loops and compare parsed timestamps directly against the cutoff to improve performance.
+## 2025-07-11 - Optimize tail() in high-frequency loops
+**Learning:** Replacing `tail(x, n)` with direct vector indexing like `x[(length(x)-n+1):length(x)]` inside grouped data.table operations significantly reduces execution time by avoiding S3 generic method dispatch overhead.
+**Action:** When extracting the last elements of a vector within a high-frequency loop or grouped data.table operation, always use direct vector indexing instead of the `tail()` function.

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -333,7 +333,7 @@ calculate_summary_stats <- function(results) {
         min       = min(v_val),
         max       = max(v_val),
         count     = n,
-        rollmean3 = if (n < 3) NA_real_ else mean(tail(v_val, 3))
+        rollmean3 = if (n < 3) NA_real_ else mean(v_val[(n - 2):n])
       )
     }
   }


### PR DESCRIPTION
💡 What: Replaced `tail(v_val, 3)` with `v_val[(n - 2):n]` in the `calc_stats` function.
🎯 Why: `tail()` is an S3 generic method in R, which introduces dispatch overhead. Bypassing this inside high-frequency grouped data.table aggregations reduces CPU cycles.
📊 Impact: Expected to reduce execution time for the summary stats calculation, particularly on larger datasets.
🔬 Measurement: Verify via benchmark or by running `tests/test_perf_sapply_vs_lapply.R` (which evaluates method overhead internally). All tests pass.

---
*PR created automatically by Jules for task [11768642844255534320](https://jules.google.com/task/11768642844255534320) started by @abhimehro*