### PR TITLE
fix(tests): path-traversal fixtures without GG Generic Password FP (salvages #493)

### DIFF
--- a/Series_27/Analysis/test_outlier_analysis_series27.py
+++ b/Series_27/Analysis/test_outlier_analysis_series27.py
@@ -146,7 +146,7 @@ from outlier_analysis_series27 import apply_corrections, secure_filename
 
 
 def test_secure_filename():
-    assert secure_filename("../../../etc/passwd") == "etc_passwd"
+    assert secure_filename("../../../outside/traversal_target") == "outside_traversal_target"
     assert secure_filename("C:\\Windows\\System32") == "C__Windows_System32"
     assert secure_filename("..") == "unnamed"
     assert secure_filename(".hidden") == "hidden"
@@ -164,7 +164,7 @@ def test_apply_corrections_path_traversal(tmp_path):
             "Sensor": [1],
             "Difference": [0.5],
             "next_year": ["2024"],
-            "sheet": ["../../../etc/passwd"],
+            "sheet": ["../../../outside/traversal_target"],
         }
     )
 
@@ -192,7 +192,7 @@ def test_apply_corrections_path_traversal(tmp_path):
         assert (
             "\\" not in filename
         ), f"Path traversal character \\ found in {filename}"
-        assert "etc_passwd" in filename
+        assert "outside_traversal_target" in filename
 
         # Defense-in-depth: resolved path must remain within output_dir
         assert os.path.realpath(out_file).startswith(

--- a/tests/test_code_health_scanner.py
+++ b/tests/test_code_health_scanner.py
@@ -84,7 +84,7 @@ def test_read_file_safe_non_existent():
 def test_get_repo_info_exception_logging(caplog):
     import logging
     with patch("subprocess.check_output") as mock_run:
-        mock_run.side_effect = Exception("Some secret internal error")
+        mock_run.side_effect = Exception("Some hidden internal error")
         with caplog.at_level(logging.ERROR):
             account, project, commit_hash = get_repo_info()
 
@@ -93,7 +93,7 @@ def test_get_repo_info_exception_logging(caplog):
         assert commit_hash == "unknown"
 
         assert "Error getting repo info: Internal error occurred (Exception)." in caplog.text
-        assert "Some secret internal error" not in caplog.text
+        assert "Some hidden internal error" not in caplog.text
 
 def test_read_file_safe_null_byte():
     # Attempting to read a file with an embedded null character should return empty list

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -74,10 +74,10 @@ def test_run_process_allowlist(mock_run):
     test_env = {
         "PATH": "/usr/bin",
         "HOME": "/home/user",
-        "AWS_ACCESS_KEY_ID": "sensitive1",
-        "NPM_TOKEN": "sensitive2",
-        "GH_TOKEN": "sensitive3",
-        "GITHUB_TOKEN": "sensitive4",
+        "AWS_ACCESS_KEY_ID": "DUMMY_VALUE_1",
+        "NPM_TOKEN": "DUMMY_VALUE_2",
+        "GH_TOKEN": "DUMMY_VALUE_3",
+        "GITHUB_TOKEN": "DUMMY_VALUE_4",
         "GITHUB_WORKSPACE": "/workspace",
     }
 
@@ -107,7 +107,7 @@ def test_run_shell_command_allowlist_and_custom(mock_run_process):
     mock_run_process.return_value = mock_proc
 
     # Ensure os.environ has some sensitive stuff for the default safe_env grab
-    with patch.dict(os.environ, {"AWS_ACCESS_KEY_ID": "sensitive1", "PATH": "/bin"}):
+    with patch.dict(os.environ, {"AWS_ACCESS_KEY_ID": "DUMMY_VALUE_1", "PATH": "/bin"}):
         result = run_shell_command(
             "echo hello",
             custom_env={"MY_VAR": "custom_val", "GH_TOKEN": "should_be_stripped"},


### PR DESCRIPTION
## Summary
Clean-history salvage of #493. GitGuardian kept failing on intermediate commit `55cd44ba` (`etc/passwd` path-traversal fixture) even after tip was cleaned. Policy forbids force-push, so this PR reapplies tip changes from `main` with no poisoned history.

## Changes
- `Series_27/Analysis/test_outlier_analysis_series27.py`: use `outside/traversal_target` instead of `etc/passwd`
- `tests/test_code_health_scanner.py`: rename mock exception text
- `tests/test_repository_automation_common.py`: `DUMMY_VALUE_*` placeholders

## Test plan
- [x] Tip has no `passwd` / sensitive mock strings
- [ ] CI green including GitGuardian
- [ ] Close #493 as superseded after merge

Closes context: https://github.com/abhimehro/Seatek_Analysis/pull/493