### PR TITLE
🛡️ Sentinel: [Medium] Suppress Bandit false positives for subprocess executions

### DIFF
--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -36,9 +36,8 @@ def get_repo_info():
             return "unknown", "unknown", "unknown"
 
         # Get origin URL
-        origin_url = subprocess.check_output(
-            ["git", "remote", "get-url", "origin"],
-            executable=git_bin,
+        origin_url = subprocess.check_output(  # nosec B603
+            [git_bin, "remote", "get-url", "origin"],
             stderr=subprocess.DEVNULL,
             env=env,
             text=True,
@@ -53,9 +52,8 @@ def get_repo_info():
         account, project = match.groups()
 
         # Get current commit hash
-        commit_hash = subprocess.check_output(
-            ["git", "rev-parse", "HEAD"],
-            executable=git_bin,
+        commit_hash = subprocess.check_output(  # nosec B603
+            [git_bin, "rev-parse", "HEAD"],
             stderr=subprocess.DEVNULL,
             env=env,
             text=True,


### PR DESCRIPTION
🚨 Severity: Medium
💡 Vulnerability: Bandit raised `B607` for partial paths despite passing absolute paths through the `executable=` arg. Furthermore it was raising `B603` for untrusted input check despite `shell=False`.
🎯 Impact: This created noise in SAST tooling that could cause us to miss a real vulnerability.
🔧 Fix: Used the full path resolved by `shutil.which` directly in the command list args to avoid `B607`. Appended `# nosec B603` to valid safe usages to silence `B603`.
✅ Verification: Ran `bandit -r code_health_scanner.py` successfully and `pytest` on the test suite to ensure tests still pass.

---
*PR created automatically by Jules for task [5065189889489302145](https://jules.google.com/task/5065189889489302145) started by @abhimehro*