### PR TITLE
chore(deps): pin Series 27 Python dependencies to exact versions (ABHI-1589)

### DIFF
--- a/.github/repository-automation.yml
+++ b/.github/repository-automation.yml
@@ -60,8 +60,6 @@ automation:
           - install
           - "-r"
           - requirements-ci.txt
-          - pre-commit
-          - bandit
         optional: false
         timeout_seconds: 1800
     commands:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff pytest pandas openpyxl matplotlib
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install -r Series_27/Analysis/requirements.txt
+          pip install -r requirements-dev.txt
 
       - name: Lint with ruff
         run: |

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
     paths:
       - "**.py"
+      - "Series_27/Analysis/requirements.txt"
       - "requirements*.txt"
       - ".github/workflows/pr-validation.yml"
 
@@ -28,8 +29,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r Series_27/Analysis/requirements.txt
-          pip install -r requirements-dev.txt
+          python -m pip install -r Series_27/Analysis/requirements.txt
+          python -m pip install -r requirements-dev.txt
 
       - name: Lint with ruff
         run: |
@@ -41,12 +42,12 @@ jobs:
       - name: Compile Python files
         run: |
           # SECURITY: Use -exec to securely handle file paths with spaces and prevent word splitting/command injection
-          find . -name "*.py" -not -path "*/venv/*" -not -path "*/.venv/*" -exec python3 -m py_compile {} +
+          find . -name "*.py" -not -path "*/venv/*" -not -path "*/.venv/*" -exec python -m py_compile {} +
 
       - name: Run tests
         run: |
           if [ -d tests ]; then
-            python3 -m pytest tests/ -v || echo "::warning::Some tests failed"
+            python -m pytest tests/ -v || echo "::warning::Some tests failed"
           else
             echo "::notice::No tests directory found, skipping pytest"
           fi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install dependencies
-        run: pip install -r Series_27/Analysis/requirements.txt
+        run: python -m pip install -r Series_27/Analysis/requirements.txt
       - name: Syntax check
         run: python -m py_compile Series_27/Analysis/outlier_analysis_series27.py code_health_scanner.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,9 @@ sensor data. See `README.md` for full details.
 - Some existing tests have pre-existing failures due to mismatched error message
   patterns; these are not environment issues.
 - The Python venv at `Series_27/Analysis/venv/` is for the optional Series 27
-  outlier analysis script only. It requires **Python 3.11 or newer**; recreate
-  it with a 3.11+ interpreter if necessary:
+  outlier analysis script only. It requires **Python 3.11 or 3.12** (the pinned
+  `numpy==1.26.0` only ships wheels for those versions); recreate it with a
+  3.11/3.12 interpreter if necessary:
   `rm -rf Series_27/Analysis/venv && python3.11 -m venv Series_27/Analysis/venv && Series_27/Analysis/venv/bin/pip install -r Series_27/Analysis/requirements.txt`.
   Recreating overwrites tracked files, so
   `git checkout -- Series_27/Analysis/venv` afterward to keep the tree clean.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,11 +54,9 @@ sensor data. See `README.md` for full details.
 - Some existing tests have pre-existing failures due to mismatched error message
   patterns; these are not environment issues.
 - The Python venv at `Series_27/Analysis/venv/` is for the optional Series 27
-  outlier analysis script only. The committed venv is broken on this VM (its
-  interpreter symlinks point to the original author's macOS path
-  `/Users/abhimehrotra/.pyenv/...`). To run the optional S27 analysis, recreate
-  it:
-  `rm -rf Series_27/Analysis/venv && python3 -m venv Series_27/Analysis/venv && Series_27/Analysis/venv/bin/pip install -r Series_27/Analysis/requirements.txt`.
+  outlier analysis script only. It requires **Python 3.11 or newer**; recreate
+  it with a 3.11+ interpreter if necessary:
+  `rm -rf Series_27/Analysis/venv && python3.11 -m venv Series_27/Analysis/venv && Series_27/Analysis/venv/bin/pip install -r Series_27/Analysis/requirements.txt`.
   Recreating overwrites tracked files, so
   `git checkout -- Series_27/Analysis/venv` afterward to keep the tree clean.
   The script requires an input workbook via `-i`, e.g.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,8 +27,10 @@ Only the latest version (`main` branch) receives security updates.
 
 ## Dependency Management
 
-- Python dependencies are managed via `requirements.txt`. Keep packages updated
-  with `pip install --upgrade -r requirements.txt`.
+- Python runtime dependencies for the Series 27 outlier analysis are pinned in
+  `Series_27/Analysis/requirements.txt`; dev/CI tools are pinned in
+  `requirements-dev.txt`. Update them through reviewed Dependabot or manual PRs
+  rather than `pip install --upgrade -r ...`.
 - R dependencies should be updated regularly with `update.packages()`.
 - Use tools like [`pip-audit`](https://pypi.org/project/pip-audit/) (Python) and
   [`renv`](https://rstudio.github.io/renv/) (R) to check for known

--- a/Series_27/Analysis/requirements.txt
+++ b/Series_27/Analysis/requirements.txt
@@ -1,8 +1,8 @@
-pandas>=3.0.5,<4.0
-numpy>=1.26,<3.0
-matplotlib>=3.11.1
-# DEPENDENCY: pillow>=12.3.0 — explicit floor for matplotlib transitive;
+pandas==3.0.5
+numpy==1.26.0
+matplotlib==3.11.1
+# DEPENDENCY: pillow — explicit pin for matplotlib transitive;
 # Pillow 12.2.0 has OSV PYSEC-2026-2253..2257 / 3451..3453 (fixed in 12.3.0)
-pillow>=12.3.0,<13.0.0
-openpyxl>=3.1.5
-defusedxml>=0.7.1
+pillow==12.3.0
+openpyxl==3.1.5
+defusedxml==0.7.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,1 +1,1 @@
-bandit>=1.7.0
+-r requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,4 @@
-bandit>=1.7.0
+bandit==1.9.4
+pre-commit==4.6.1
+pytest==9.1.1
+ruff==0.16.0

--- a/setup.sh
+++ b/setup.sh
@@ -15,15 +15,19 @@ if command -v apt-get &>/dev/null; then
 		echo "R not found. Installing R and build tools..."
 		apt-get install -y -qq r-base r-base-dev
 	fi
+
+	# Ensure Python and venv/pip tooling are available before the version guard.
+	echo "Ensuring Python3, venv, and pip are installed..."
+	apt-get install -y -qq python3 python3-venv python3-pip
 fi
 
-# Ensure Python 3.11+ is available for the Series 27 analysis environment.
-# Prefer a versioned interpreter (3.13 > 3.12 > 3.11) over the generic `python3`.
+# Ensure a Python 3.11/3.12 interpreter is available for the Series 27 analysis
+# environment. The pinned numpy==1.26.0 only ships wheels for 3.11/3.12, so we
+# restrict the guard to that range to avoid a source-build failure on 3.13+.
 PYTHON_BIN=""
-for py in python3.13 python3.12 python3.11 python3; do
+for py in python3.11 python3.12 python3; do
 	if command -v "$py" &>/dev/null; then
-		minor=$("$py" -c "import sys; print(sys.version_info.minor)" 2>/dev/null || echo 0)
-		if [ "$minor" -ge 11 ]; then
+		if "$py" -c "import sys; sys.exit(0 if (3, 11) <= sys.version_info[:2] <= (3, 12) else 1)" 2>/dev/null; then
 			PYTHON_BIN="$py"
 			break
 		fi
@@ -31,17 +35,11 @@ for py in python3.13 python3.12 python3.11 python3; do
 done
 
 if [ -z "$PYTHON_BIN" ]; then
-	echo "Error: Python 3.11 or newer is required for the Series 27 analysis environment." >&2
+	echo "Error: Python 3.11 or 3.12 is required for the Series 27 analysis environment." >&2
 	exit 1
 fi
 
 echo "Using Python interpreter: $PYTHON_BIN ($($PYTHON_BIN --version))"
-
-# Ensure Python and venv/pip tooling are available
-if command -v apt-get &>/dev/null; then
-	echo "Ensuring Python3, venv, and pip are installed..."
-	apt-get install -y -qq python3 python3-venv python3-pip
-fi
 
 # Restore R packages from the lockfile
 echo "Restoring R packages with renv..."

--- a/setup.sh
+++ b/setup.sh
@@ -21,9 +21,20 @@ if command -v apt-get &>/dev/null; then
 	apt-get install -y -qq python3 python3-venv python3-pip
 fi
 
+# Restore R packages from the lockfile (core pipeline, independent of Python)
+echo "Restoring R packages with renv..."
+Rscript -e "if (!requireNamespace('renv', quietly = TRUE)) install.packages('renv', repos = 'https://cloud.r-project.org'); renv::restore()" | tee renv_restore.log
+
+# Optional Series 27 Python environment
+VENV_DIR="Series_27/Analysis/venv"
+REQUIREMENTS_FILE="Series_27/Analysis/requirements.txt"
+REQUIREMENTS_DEV_FILE="requirements-dev.txt"
+
 # Ensure a Python 3.11/3.12 interpreter is available for the Series 27 analysis
 # environment. The pinned numpy==1.26.0 only ships wheels for 3.11/3.12, so we
 # restrict the guard to that range to avoid a source-build failure on 3.13+.
+# Because the Python analysis is optional, a missing/unsupported interpreter is
+# treated as a warning rather than a fatal error.
 PYTHON_BIN=""
 for py in python3.11 python3.12 python3; do
 	if command -v "$py" &>/dev/null; then
@@ -35,36 +46,50 @@ for py in python3.11 python3.12 python3; do
 done
 
 if [ -z "$PYTHON_BIN" ]; then
-	echo "Error: Python 3.11 or 3.12 is required for the Series 27 analysis environment." >&2
-	exit 1
+	echo "Warning: No Python 3.11 or 3.12 interpreter found; skipping optional Series 27 Python venv setup." >&2
+	echo "Dependency setup complete (R packages restored; Series 27 Python venv skipped)."
+	exit 0
 fi
 
 echo "Using Python interpreter: $PYTHON_BIN ($($PYTHON_BIN --version))"
 
-# Restore R packages from the lockfile
-echo "Restoring R packages with renv..."
-Rscript -e "if (!requireNamespace('renv', quietly = TRUE)) install.packages('renv', repos = 'https://cloud.r-project.org'); renv::restore()" | tee renv_restore.log
-
-# Setup Python virtual environment
-VENV_DIR="Series_27/Analysis/venv"
-REQUIREMENTS_FILE="Series_27/Analysis/requirements.txt"
-REQUIREMENTS_DEV_FILE="requirements-dev.txt"
+# Setup or validate the Series 27 virtual environment
 if [ ! -d "$VENV_DIR" ]; then
 	echo "Creating Python virtual environment at $VENV_DIR..."
 	"$PYTHON_BIN" -m venv "$VENV_DIR"
+else
+	# If a venv already exists (e.g. the tracked placeholder), verify it uses a
+	# compatible Python before installing into it.
+	VENV_PYTHON="$VENV_DIR/bin/python"
+	if [ -f "$VENV_PYTHON" ]; then
+		if ! "$VENV_PYTHON" -c "import sys; sys.exit(0 if (3, 11) <= sys.version_info[:2] <= (3, 12) else 1)" 2>/dev/null; then
+			echo "Warning: Existing venv at $VENV_DIR does not use Python 3.11/3.12. Recreate it with:" >&2
+			echo "  rm -rf $VENV_DIR && $PYTHON_BIN -m venv $VENV_DIR" >&2
+			PYTHON_BIN=""
+		fi
+	else
+		echo "Warning: Existing venv at $VENV_DIR is missing its python binary; skipping Python package install." >&2
+		PYTHON_BIN=""
+	fi
 fi
 
-echo "Installing Python packages from $REQUIREMENTS_FILE..."
-if [ -f "$REQUIREMENTS_FILE" ]; then
-	source "$VENV_DIR/bin/activate"
-	pip install --upgrade pip
-	pip install -r "$REQUIREMENTS_FILE"
-	if [ -f "$REQUIREMENTS_DEV_FILE" ]; then
-		pip install -r "$REQUIREMENTS_DEV_FILE"
+if [ -n "$PYTHON_BIN" ]; then
+	echo "Installing Python packages from $REQUIREMENTS_FILE..."
+	if [ -f "$REQUIREMENTS_FILE" ]; then
+		if [ -f "$VENV_DIR/bin/activate" ]; then
+			source "$VENV_DIR/bin/activate"
+			python -m pip install --upgrade pip
+			python -m pip install -r "$REQUIREMENTS_FILE"
+			if [ -f "$REQUIREMENTS_DEV_FILE" ]; then
+				python -m pip install -r "$REQUIREMENTS_DEV_FILE"
+			fi
+			deactivate
+		else
+			echo "Warning: activate script missing in $VENV_DIR; skipping Python package install."
+		fi
+	else
+		echo "Warning: Requirements file $REQUIREMENTS_FILE not found."
 	fi
-	deactivate
-else
-	echo "Warning: Requirements file $REQUIREMENTS_FILE not found."
 fi
 
 echo "Dependency setup complete."

--- a/setup.sh
+++ b/setup.sh
@@ -17,6 +17,26 @@ if command -v apt-get &>/dev/null; then
 	fi
 fi
 
+# Ensure Python 3.11+ is available for the Series 27 analysis environment.
+# Prefer a versioned interpreter (3.13 > 3.12 > 3.11) over the generic `python3`.
+PYTHON_BIN=""
+for py in python3.13 python3.12 python3.11 python3; do
+	if command -v "$py" &>/dev/null; then
+		minor=$("$py" -c "import sys; print(sys.version_info.minor)" 2>/dev/null || echo 0)
+		if [ "$minor" -ge 11 ]; then
+			PYTHON_BIN="$py"
+			break
+		fi
+	fi
+done
+
+if [ -z "$PYTHON_BIN" ]; then
+	echo "Error: Python 3.11 or newer is required for the Series 27 analysis environment." >&2
+	exit 1
+fi
+
+echo "Using Python interpreter: $PYTHON_BIN ($($PYTHON_BIN --version))"
+
 # Ensure Python and venv/pip tooling are available
 if command -v apt-get &>/dev/null; then
 	echo "Ensuring Python3, venv, and pip are installed..."
@@ -30,9 +50,10 @@ Rscript -e "if (!requireNamespace('renv', quietly = TRUE)) install.packages('ren
 # Setup Python virtual environment
 VENV_DIR="Series_27/Analysis/venv"
 REQUIREMENTS_FILE="Series_27/Analysis/requirements.txt"
+REQUIREMENTS_DEV_FILE="requirements-dev.txt"
 if [ ! -d "$VENV_DIR" ]; then
 	echo "Creating Python virtual environment at $VENV_DIR..."
-	python3 -m venv "$VENV_DIR"
+	"$PYTHON_BIN" -m venv "$VENV_DIR"
 fi
 
 echo "Installing Python packages from $REQUIREMENTS_FILE..."
@@ -40,7 +61,9 @@ if [ -f "$REQUIREMENTS_FILE" ]; then
 	source "$VENV_DIR/bin/activate"
 	pip install --upgrade pip
 	pip install -r "$REQUIREMENTS_FILE"
-	pip install bandit
+	if [ -f "$REQUIREMENTS_DEV_FILE" ]; then
+		pip install -r "$REQUIREMENTS_DEV_FILE"
+	fi
 	deactivate
 else
 	echo "Warning: Requirements file $REQUIREMENTS_FILE not found."


### PR DESCRIPTION
## Summary

Pins all direct Python dependencies for the Series 27 outlier analysis to exact `==` versions, and aligns CI/setup tooling so nothing reinstalls those packages unpinned.

Closes [ABHI-1589](https://linear.app/abhis-space/issue/ABHI-1589/supply-chain-pin-all-dependencies-to-specific-versions).

### What changed

- `Series_27/Analysis/requirements.txt` — pinned runtime packages:
  ```text
  pandas==3.0.5
  numpy==1.26.0
  matplotlib==3.11.1
  pillow==12.3.0
  openpyxl==3.1.5
  defusedxml==0.7.1
  ```
- `requirements-dev.txt` / `requirements-ci.txt` — pinned dev/CI tools (`bandit==1.9.4`, `pre-commit==4.6.1`, `pytest==9.1.1`, `ruff==0.16.0`) and made `requirements-ci.txt` reference the dev manifest.
- `setup.sh` — added a Python 3.11/3.12 interpreter guard and switched from unpinned `pip install bandit` to installing from `requirements-dev.txt`.
- `.github/workflows/pr-validation.yml` — now installs runtime deps from `Series_27/Analysis/requirements.txt` and dev tools from `requirements-dev.txt`, uses `python -m` consistently, and includes the nested requirements file in the `paths` filter.
- `.github/workflows/pr.yml` — also uses `python -m pip install`.
- `.github/repository-automation.yml` — removed the unpinned `pre-commit` and `bandit` arguments from the CI install command.
- `AGENTS.md` / `SECURITY.md` — documented the Python 3.11/3.12 requirement and pointed dependency updates at the pinned manifests.

### Review fixes

- Moved the apt Python tooling install before the `setup.sh` version guard so a fresh system gets `python3` before the guard runs.
- Reversed interpreter preference to `python3.11` → `python3.12` → `python3` and restricted the guard to 3.11–3.12 because `numpy==1.26.0` does not ship wheels for Python 3.13.
- Added `Series_27/Analysis/requirements.txt` to `pr-validation.yml` paths so dependency edits trigger validation.
- Switched `pr-validation.yml` and `pr.yml` to `python -m pip install` / `python -m py_compile` / `python -m pytest` for interpreter consistency.
- Moved the Python guard after the R `renv::restore()` and made a missing/unsupported Python a warning rather than a fatal error, so the optional Series 27 venv does not block the core R environment setup.
- Added a venv-compatibility check so an existing tracked venv with an incompatible Python is warned and skipped instead of being used blindly.

### Verification

- Clean 3.11/3.12 resolve: `python -m pip install -r Series_27/Analysis/requirements.txt` and `python -m pip install -r requirements-dev.txt` succeed.
- `python -m py_compile` passes for all repo `.py` files.
- `python -m pytest tests/` passes (30/30).
- `python -m pytest Series_27/Analysis/test_outlier_analysis_series27.py` passes 8/9; the remaining failure (`test_apply_corrections_path_traversal`) is a pre-existing fixture issue unrelated to dependency pinning.
- CLI smoke test ran successfully against `Series_27/Analysis/Seatek_Comprehensive_Analysis.xlsx`, producing `corrections_summary.xlsx` and `outliers_plot.png`.

### Out of scope

- No full transitive lockfile (`pip freeze` / `uv lock`) — direct pins close the P1 supply-chain finding and remain Dependabot-friendly.
- The committed `Series_27/Analysis/venv` was not regenerated or committed.
- Python 3.10 support is not restored; the pinned `pandas==3.0.5` and `matplotlib==3.11.1` require 3.11+.

Link to Devin session: https://app.devin.ai/sessions/ae1c6bb24ede4e9b83acb936ab7e15a3
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->