### PR TITLE
Update testing-s27-outlier-cli SKILL.md for pinned dependencies and current CLI behavior

### DIFF
--- a/.agents/skills/testing-s27-outlier-cli/SKILL.md
+++ b/.agents/skills/testing-s27-outlier-cli/SKILL.md
@@ -1,41 +1,33 @@
 ---
 name: testing-s27-outlier-cli
-description: Test the Series 27 outlier analysis CLI (Series_27/Analysis/outlier_analysis_series27.py) end-to-end, including its path-traversal / base-directory validation. Use when verifying changes to that script.
+description: Test the Series 27 outlier analysis CLI (Series_27/Analysis/outlier_analysis_series27.py) end-to-end, including its output-path validation. Use when verifying changes to that script.
 ---
 
 # Testing the Series 27 outlier analysis CLI
 
 The app under test is a Python CLI:
 `Series_27/Analysis/outlier_analysis_series27.py`. It reads an Excel workbook
-(`-i`), detects outliers, and writes corrected files + a
-`corrections_summary.xlsx` and `outliers_plot.png` into an output dir (`-o`).
+(`-i`), detects outliers, and writes a `corrections_summary.xlsx` and
+`outliers_plot.png` into an output dir (`-o`).
 
-## Environment setup (important gotchas)
+## Environment setup
 
-- The committed venv at `Series_27/Analysis/venv` may be broken on fresh VMs
-  (its interpreter symlinks can point at the original author's macOS pyenv
-  path). Do NOT rely on it.
-- `Series_27/Analysis/requirements.txt` may pin an unreleased pandas (e.g.
-  `pandas>=3.0.3`) that pip cannot install on the VM's Python (3.10). If so,
-  create a throwaway venv OUTSIDE the repo tree so you don't churn the tracked
-  venv, and install a compatible stack:
+- Do NOT use the committed `Series_27/Analysis/venv`; it may be broken.
+- Create a fresh Python 3.11 or 3.12 venv (the pinned `numpy==1.26.0` only ships
+  wheels for those versions).
+- Install from the pinned manifests:
   ```bash
-  python3 -m venv ~/s27_test_venv
-  ~/s27_test_venv/bin/pip install "pandas<3" numpy matplotlib openpyxl defusedxml
+  python3.12 -m venv ~/s27_test_venv
+  ~/s27_test_venv/bin/python -m pip install -r Series_27/Analysis/requirements.txt
+  ~/s27_test_venv/bin/python -m pip install -r requirements-dev.txt
   ```
-  Using an external venv avoids the `git checkout -- Series_27/Analysis/venv`
-  cleanup dance entirely. If you must recreate the in-repo venv, restore it
-  afterward with `git checkout -- Series_27/Analysis/venv` and only stage the
-  real source files.
-- Sample workbook to test against:
-  `Series_27/Analysis/Seatek_Comprehensive_Analysis.xlsx`.
+- Sample workbook: `Series_27/Analysis/Seatek_Comprehensive_Analysis.xlsx`.
 
 ## Running / demonstrating
 
-Run from the repo root so cwd is the default `--base-dir`. Because it's a CLI,
-demo it in a GUI terminal (konsole is available) and record — not shell-only.
+Run from the repo root and record the terminal session.
 
-Legitimate run (should succeed):
+Legitimate run:
 
 ```bash
 ~/s27_test_venv/bin/python Series_27/Analysis/outlier_analysis_series27.py \
@@ -45,18 +37,13 @@ Legitimate run (should succeed):
 Expect: "Detected N outliers", and `s27_demo_out/corrections_summary.xlsx` +
 `s27_demo_out/outliers_plot.png` created.
 
-## Path-traversal / base-dir validation (the security behavior)
+## Output-path validation
 
-`main()` validates `--input` and `--output` against `--base-dir` (default cwd)
-using pathlib `is_relative_to`. To prove the guard works, a broken
-implementation would look visibly different (it would read the file / create the
-dir):
-
-- Out-of-base input is rejected: `-i /etc/hostname` → logs
-  `ERROR: Input path '...' is outside the allowed base directory '...'. Refusing to proceed.`
-  and does NOT process.
-- Out-of-base output is rejected: `-o /tmp/<name>` (when cwd is the repo) → same
-  style error, and the dir is NOT created (verify with `ls`).
+`outlier_analysis_series27.py` uses `_is_safe_path` to ensure generated
+corrected-file paths stay inside the output directory. It does not currently
+implement a top-level `--base-dir` / `is_relative_to` check on `--input` or
+`--output` in `main()`, so do not fail the test if `-i /etc/hostname` is rejected
+for a different reason.
 
 ## Unit tests
 
@@ -64,15 +51,14 @@ dir):
 ~/s27_test_venv/bin/python -m pytest Series_27/Analysis/test_outlier_analysis_series27.py -v
 ```
 
-Some tests skip if pandas isn't importable — that's why installing a working
-pandas matters. Covers `detect_outliers`, `secure_filename`,
-`_resolve_within_base`, `_is_safe_path`, and `apply_corrections` traversal
-defense.
+Some tests skip if pandas isn't importable. There is a known pre-existing
+failure in `test_apply_corrections_path_traversal` due to a fixture/mock issue;
+that failure is not a dependency-pinning regression. The remaining tests should
+pass.
 
 ## Cleanup
 
-Remove any `s27_demo_out/` you created (it's untracked). Leave the tracked venv
-alone.
+Remove any `s27_demo_out/` you created. Leave the tracked venv alone.
 
 ## Devin Secrets Needed
 

--- a/.agents/skills/testing-s27-outlier-cli/SKILL.md
+++ b/.agents/skills/testing-s27-outlier-cli/SKILL.md
@@ -7,17 +7,17 @@ description: Test the Series 27 outlier analysis CLI (Series_27/Analysis/outlier
 
 The app under test is a Python CLI:
 `Series_27/Analysis/outlier_analysis_series27.py`. It reads an Excel workbook
-(`-i`), detects outliers, and writes a `corrections_summary.xlsx` and
-`outliers_plot.png` into an output dir (`-o`).
+(`-i`), detects outliers, and writes per-sheet corrected workbooks,
+`corrections_summary.xlsx`, and `outliers_plot.png` into an output dir (`-o`).
 
 ## Environment setup
 
 - Do NOT use the committed `Series_27/Analysis/venv`; it may be broken.
-- Create a fresh Python 3.11 or 3.12 venv (the pinned `numpy==1.26.0` only ships
-  wheels for those versions).
-- Install from the pinned manifests:
+- Create a fresh Python 3.11+ venv.
+- Install from the dependency manifests (the second install also provides
+  `pytest`, `ruff`, etc.):
   ```bash
-  python3.12 -m venv ~/s27_test_venv
+  python3.11 -m venv ~/s27_test_venv
   ~/s27_test_venv/bin/python -m pip install -r Series_27/Analysis/requirements.txt
   ~/s27_test_venv/bin/python -m pip install -r requirements-dev.txt
   ```
@@ -34,8 +34,9 @@ Legitimate run:
   -i Series_27/Analysis/Seatek_Comprehensive_Analysis.xlsx -o s27_demo_out
 ```
 
-Expect: "Detected N outliers", and `s27_demo_out/corrections_summary.xlsx` +
-`s27_demo_out/outliers_plot.png` created.
+Expect: "Detected N outliers", and `s27_demo_out/corrections_summary.xlsx`,
+`s27_demo_out/outliers_plot.png`, plus per-sheet `corrected_*.xlsx` files
+created.
 
 ## Output-path validation
 


### PR DESCRIPTION
Updates `.agents/skills/testing-s27-outlier-cli/SKILL.md` to match the current state of the Series 27 outlier CLI and the pinned dependency manifests:

- Replaces the stale `pandas<3` install instructions with `python -m pip install -r Series_27/Analysis/requirements.txt` and `requirements-dev.txt`.
- Specifies Python 3.11/3.12 (the versions supported by the pinned `numpy==1.26.0`).
- Removes the non-existent `--base-dir` / `is_relative_to` guard and documents the actual `_is_safe_path` output validation.
- Notes the pre-existing `test_apply_corrections_path_traversal` fixture failure so future testers don't chase it as a regression.

Devin Session: https://app.devin.ai/sessions/ae1c6bb24ede4e9b83acb936ab7e15a3