### PR TITLE
🧪 Add tests for command_env to improve test reliability

### DIFF
--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -15,13 +15,17 @@ from repository_automation_common import (
 )
 
 
-@patch("repository_automation_common.run_process")
-def test_run_shell_command_string(mock_run_process):
+def setup_mock_process(mock_run_process):
     mock_proc = MagicMock()
     mock_proc.returncode = 0
     mock_proc.stdout = "output"
     mock_proc.stderr = ""
     mock_run_process.return_value = mock_proc
+
+
+@patch("repository_automation_common.run_process")
+def test_run_shell_command_string(mock_run_process):
+    setup_mock_process(mock_run_process)
 
     result = run_shell_command("echo hello")
 
@@ -34,11 +38,7 @@ def test_run_shell_command_string(mock_run_process):
 
 @patch("repository_automation_common.run_process")
 def test_run_shell_command_list(mock_run_process):
-    mock_proc = MagicMock()
-    mock_proc.returncode = 0
-    mock_proc.stdout = "output"
-    mock_proc.stderr = ""
-    mock_run_process.return_value = mock_proc
+    setup_mock_process(mock_run_process)
 
     result = run_shell_command(["echo", "hello"])
 
@@ -62,11 +62,7 @@ def test_target_ref_skips_commit_pins() -> None:
 
 @patch("repository_automation_common.subprocess.run")
 def test_run_process_allowlist(mock_run):
-    mock_proc = MagicMock()
-    mock_proc.returncode = 0
-    mock_proc.stdout = "output"
-    mock_proc.stderr = ""
-    mock_run.return_value = mock_proc
+    setup_mock_process(mock_run)
 
     from repository_automation_common import run_process
 
@@ -100,11 +96,7 @@ def test_run_process_allowlist(mock_run):
 
 @patch("repository_automation_common.run_process")
 def test_run_shell_command_allowlist_and_custom(mock_run_process):
-    mock_proc = MagicMock()
-    mock_proc.returncode = 0
-    mock_proc.stdout = "output"
-    mock_proc.stderr = ""
-    mock_run_process.return_value = mock_proc
+    setup_mock_process(mock_run_process)
 
     # Ensure os.environ has some sensitive stuff for the default safe_env grab
     with patch.dict(os.environ, {"AWS_ACCESS_KEY_ID": "DUMMY_VALUE_1", "PATH": "/bin"}):

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -7,6 +7,7 @@ sys.path.insert(
 )
 from repository_automation_common import (
     BASH_BIN,
+    command_env,
     is_commit_sha,
     numeric_version,
     run_shell_command,
@@ -124,3 +125,11 @@ def test_run_shell_command_allowlist_and_custom(mock_run_process):
 
         # Check GH_TOKEN explicitly stripped even if in custom_env
         assert "GH_TOKEN" not in passed_env
+
+
+def test_command_env() -> None:
+    # Test that existing env is preserved and GH_PAGER is forced to cat
+    with patch.dict(os.environ, {"MY_TEST_VAR": "hello", "GH_PAGER": "less"}, clear=True):
+        env = command_env()
+        assert env.get("MY_TEST_VAR") == "hello"
+        assert env.get("GH_PAGER") == "cat"


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `command_env` function in `repository_automation_common.py` was missing test coverage. This function ensures that execution environments correctly inherit `os.environ` while securely overriding/forcing specific variables (like `GH_PAGER`).

📊 **Coverage:** What scenarios are now tested
Added `test_command_env` to `test_repository_automation_common.py` which mocks `os.environ` using `patch.dict`. It verifies two scenarios:
1. Existing valid variables are preserved (e.g., `MY_TEST_VAR`).
2. Hardcoded override variables (e.g., `GH_PAGER`) are correctly forced to their intended values (`cat`), even if previously present in the environment.

✨ **Result:** The improvement in test coverage
We now have automated guarantees that the base process environment builder works safely and correctly, enabling more confident refactoring of shell execution utilities without fear of regressions.

---
*PR created automatically by Jules for task [8660224642517585150](https://jules.google.com/task/8660224642517585150) started by @abhimehro*