### PR TITLE
🧪 [testing improvement] Add missing tests for iso_day

### DIFF
--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -16,13 +16,19 @@ from repository_automation_common import (
 )
 
 
-@patch("repository_automation_common.run_process")
-def test_run_shell_command_string(mock_run_process):
+def _create_mock_process():
     mock_proc = MagicMock()
     mock_proc.returncode = 0
     mock_proc.stdout = "output"
     mock_proc.stderr = ""
-    mock_run_process.return_value = mock_proc
+    return mock_proc
+
+
+
+
+@patch("repository_automation_common.run_process")
+def test_run_shell_command_string(mock_run_process):
+    mock_run_process.return_value = _create_mock_process()
 
     result = run_shell_command("echo hello")
 
@@ -35,11 +41,7 @@ def test_run_shell_command_string(mock_run_process):
 
 @patch("repository_automation_common.run_process")
 def test_run_shell_command_list(mock_run_process):
-    mock_proc = MagicMock()
-    mock_proc.returncode = 0
-    mock_proc.stdout = "output"
-    mock_proc.stderr = ""
-    mock_run_process.return_value = mock_proc
+    mock_run_process.return_value = _create_mock_process()
 
     result = run_shell_command(["echo", "hello"])
 
@@ -63,11 +65,7 @@ def test_target_ref_skips_commit_pins() -> None:
 
 @patch("repository_automation_common.subprocess.run")
 def test_run_process_allowlist(mock_run):
-    mock_proc = MagicMock()
-    mock_proc.returncode = 0
-    mock_proc.stdout = "output"
-    mock_proc.stderr = ""
-    mock_run.return_value = mock_proc
+    mock_run.return_value = _create_mock_process()
 
     from repository_automation_common import run_process
 
@@ -101,11 +99,7 @@ def test_run_process_allowlist(mock_run):
 
 @patch("repository_automation_common.run_process")
 def test_run_shell_command_allowlist_and_custom(mock_run_process):
-    mock_proc = MagicMock()
-    mock_proc.returncode = 0
-    mock_proc.stdout = "output"
-    mock_proc.stderr = ""
-    mock_run_process.return_value = mock_proc
+    mock_run_process.return_value = _create_mock_process()
 
     # Ensure os.environ has some sensitive stuff for the default safe_env grab
     with patch.dict(os.environ, {"AWS_ACCESS_KEY_ID": "DUMMY_VALUE_1", "PATH": "/bin"}):

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -1,4 +1,5 @@
 import os
+import datetime as dt
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -8,6 +9,7 @@ sys.path.insert(
 from repository_automation_common import (
     BASH_BIN,
     is_commit_sha,
+    iso_day,
     numeric_version,
     run_shell_command,
     target_ref,
@@ -124,3 +126,19 @@ def test_run_shell_command_allowlist_and_custom(mock_run_process):
 
         # Check GH_TOKEN explicitly stripped even if in custom_env
         assert "GH_TOKEN" not in passed_env
+
+def test_iso_day_with_value():
+    # Use a timezone-aware datetime just to ensure we correctly use .date() regardless
+    known_time = dt.datetime(2024, 10, 15, 12, 30, 45, tzinfo=dt.UTC)
+    result = iso_day(known_time)
+    assert result == "2024-10-15"
+
+@patch("repository_automation_common.now_utc")
+def test_iso_day_default(mock_now_utc):
+    mock_time = dt.datetime(2023, 5, 2, 8, 15, 0, tzinfo=dt.UTC)
+    mock_now_utc.return_value = mock_time
+
+    result = iso_day()
+
+    mock_now_utc.assert_called_once()
+    assert result == "2023-05-02"


### PR DESCRIPTION
🎯 **What:** The `iso_day` function in `.github/scripts/repository_automation_common.py` lacked explicit test coverage for both its default behavior (returning the current date) and its behavior with explicitly provided arguments.

📊 **Coverage:** Two tests were added:
*   `test_iso_day_with_value`: Tests providing an explicit timezone-aware `datetime` object, ensuring correct date extraction.
*   `test_iso_day_default`: Mocks the underlying `now_utc()` dependency to verify the fallback behavior triggers correctly without arguments.

✨ **Result:** Test coverage for `iso_day` is now complete, providing a regression safety net for refactoring or modifications.

═════ ELIR ═════
PURPOSE: Increases unit test coverage for the `iso_day` string-formatting utility function.
SECURITY: N/A - test addition only.
FAILS IF: The implementation of `iso_day` is modified in a way that breaks `.date().isoformat()` assumptions.
VERIFY: Full test suite continues to pass.
MAINTAIN: Update tests if the default timezone or timestamp resolution defaults change.

---
*PR created automatically by Jules for task [15117683476222239507](https://jules.google.com/task/15117683476222239507) started by @abhimehro*