### PR TITLE
🧹 [code health improvement] Remove unused get_language function

### DIFF
--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -116,10 +116,3 @@ def read_file_safe(filepath):
         return []
 
 
-LANG_MAP = {".py": "python", ".r": "r", ".js": "javascript", ".ts": "typescript"}
-
-
-def get_language(filepath):
-    """Determines language based on file extension."""
-    ext = os.path.splitext(filepath)[1].lower()
-    return LANG_MAP.get(ext, "unknown")

--- a/tests/test_code_health_scanner.py
+++ b/tests/test_code_health_scanner.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 from code_health_scanner import (
     MAX_FILE_SIZE,
-    get_language,
     get_repo_info,
     read_file_safe,
 )
@@ -46,12 +45,6 @@ def test_get_repo_info_failure():
         assert commit_hash == "unknown"
 
 
-def test_get_language():
-    assert get_language("test.py") == "python"
-    assert get_language("test.R") == "r"
-    assert get_language("test.js") == "javascript"
-    assert get_language("test.ts") == "typescript"
-    assert get_language("test.txt") == "unknown"
 
 
 def test_read_file_safe_happy_path():


### PR DESCRIPTION
🎯 **What:** Removed the unused `get_language` function and its associated `LANG_MAP` from `code_health_scanner.py`. Also removed its unit test from `tests/test_code_health_scanner.py`.

💡 **Why:** The `get_language` function was not being invoked anywhere in the module, resulting in dead code. Removing it improves the maintainability and readability of the codebase without altering any functionality.

✅ **Verification:** Verified the code health issue was resolved by removing the function and dictionary. Ran the Python test suite, and all tests passed successfully, confirming no functionality was broken.

✨ **Result:** The codebase is cleaner and easier to maintain without the unused function.

---
*PR created automatically by Jules for task [4759942247647226759](https://jules.google.com/task/4759942247647226759) started by @abhimehro*