### PR TITLE
🧪 [add tests for filter_env_securely allowlist and heuristic logic]

### DIFF
--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -124,3 +124,50 @@ def test_run_shell_command_allowlist_and_custom(mock_run_process):
 
         # Check GH_TOKEN explicitly stripped even if in custom_env
         assert "GH_TOKEN" not in passed_env
+
+
+def test_filter_env_securely():
+    from repository_automation_common import filter_env_securely
+
+    base_env = {
+        "PATH": "/usr/bin",
+        "HOME": "/home/user",
+        "GITHUB_WORKSPACE": "/workspace",
+        "UNSAFE_VAR": "secret_data",
+        "MY_TOKEN": "DUMMY_VALUE_1",
+        "RANDOM_PASSWORD": "DUMMY_VALUE_2",
+        "AWS_SECRET_KEY": "DUMMY_VALUE_3",
+        "GITHUB_SECRET": "should_be_stripped",
+        "GITHUB_PASSWORD": "dummy",
+        "GITHUB_KEY": "dummy",
+    }
+    custom_env = {
+        "MY_CUSTOM_VAR": "custom_value",
+        "GH_TOKEN": "should_be_stripped",
+        "GITHUB_TOKEN": "should_be_stripped_too",
+    }
+
+    result = filter_env_securely(base_env, custom_env)
+
+    # 1. Allowlist preservation
+    assert result.get("PATH") == "/usr/bin"
+    assert result.get("HOME") == "/home/user"
+    assert result.get("GITHUB_WORKSPACE") == "/workspace"
+
+    # 2. Removal of variables not in the allowlist
+    assert "UNSAFE_VAR" not in result
+
+    # 3. Removal of heuristic secrets in the base environment
+    assert "MY_TOKEN" not in result
+    assert "RANDOM_PASSWORD" not in result
+    assert "AWS_SECRET_KEY" not in result
+    assert "GITHUB_SECRET" not in result
+    assert "GITHUB_PASSWORD" not in result
+    assert "GITHUB_KEY" not in result
+
+    # 4. Preservation of explicitly provided custom_env variables
+    assert result.get("MY_CUSTOM_VAR") == "custom_value"
+
+    # 5. Strict removal of GH_TOKEN and GITHUB_TOKEN even if provided in custom_env
+    assert "GH_TOKEN" not in result
+    assert "GITHUB_TOKEN" not in result

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -2,6 +2,14 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
+def create_mock_process():
+    mock_proc = MagicMock()
+    mock_proc.returncode = 0
+    mock_proc.stdout = "output"
+    mock_proc.stderr = ""
+    return mock_proc
+
+
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.github/scripts"))
 )
@@ -16,10 +24,7 @@ from repository_automation_common import (
 
 @patch("repository_automation_common.run_process")
 def test_run_shell_command_string(mock_run_process):
-    mock_proc = MagicMock()
-    mock_proc.returncode = 0
-    mock_proc.stdout = "output"
-    mock_proc.stderr = ""
+    mock_proc = create_mock_process()
     mock_run_process.return_value = mock_proc
 
     result = run_shell_command("echo hello")
@@ -33,10 +38,7 @@ def test_run_shell_command_string(mock_run_process):
 
 @patch("repository_automation_common.run_process")
 def test_run_shell_command_list(mock_run_process):
-    mock_proc = MagicMock()
-    mock_proc.returncode = 0
-    mock_proc.stdout = "output"
-    mock_proc.stderr = ""
+    mock_proc = create_mock_process()
     mock_run_process.return_value = mock_proc
 
     result = run_shell_command(["echo", "hello"])
@@ -61,10 +63,7 @@ def test_target_ref_skips_commit_pins() -> None:
 
 @patch("repository_automation_common.subprocess.run")
 def test_run_process_allowlist(mock_run):
-    mock_proc = MagicMock()
-    mock_proc.returncode = 0
-    mock_proc.stdout = "output"
-    mock_proc.stderr = ""
+    mock_proc = create_mock_process()
     mock_run.return_value = mock_proc
 
     from repository_automation_common import run_process
@@ -99,10 +98,7 @@ def test_run_process_allowlist(mock_run):
 
 @patch("repository_automation_common.run_process")
 def test_run_shell_command_allowlist_and_custom(mock_run_process):
-    mock_proc = MagicMock()
-    mock_proc.returncode = 0
-    mock_proc.stdout = "output"
-    mock_proc.stderr = ""
+    mock_proc = create_mock_process()
     mock_run_process.return_value = mock_proc
 
     # Ensure os.environ has some sensitive stuff for the default safe_env grab


### PR DESCRIPTION
🎯 **What:** The `filter_env_securely` function in `.github/scripts/repository_automation_common.py` previously lacked dedicated unit tests, particularly for its allowlist logic and defense-in-depth secret heuristic filtering.

📊 **Coverage:** A new test function `test_filter_env_securely` was added to `tests/test_repository_automation_common.py`. It thoroughly validates:
- Preservation of explicitly allowlisted environment variables (`PATH`, `HOME`).
- Preservation of variables matching allowed prefixes (`GITHUB_WORKSPACE`).
- Removal of unsafe, non-allowlisted variables.
- The `_remove_heuristic_secrets` logic, tested by supplying dummy secrets that bypass the prefix allowlist (e.g., `GITHUB_SECRET`, `GITHUB_PASSWORD`) but are correctly caught and stripped by the heuristic algorithm.
- Preservation of non-sensitive `custom_env` variables.
- Explicit and strict stripping of high-value tokens like `GH_TOKEN` and `GITHUB_TOKEN`, even if deliberately injected via `custom_env`.

✨ **Result:** The credential filtering logic is now explicitly tested, significantly improving the reliability of the repository automation pipeline. Future changes to the environment scrubbing logic will be caught by this safety net, preventing accidental exfiltration of secrets to untrusted subprocesses.

═════ ELIR ═════
PURPOSE: Added test coverage to verify that `filter_env_securely` correctly filters environment variables according to its allowlist and heuristic rules.
SECURITY: Ensures that credential exfiltration protections (allowlists and heuristic stripping) cannot silently break during future refactors.
FAILS IF: The heuristic stripping logic or allowlist definitions are changed in a way that allows sensitive keywords to bypass filtering.
VERIFY: The unit test correctly applies realistic dummy environment variables that exercise both the allowlist (prefix bypass) and the heuristic logic.
MAINTAIN: When adding new patterns to the secret heuristic, update `test_filter_env_securely` to cover them.

---
*PR created automatically by Jules for task [16473218486059511873](https://jules.google.com/task/16473218486059511873) started by @abhimehro*