### PR TITLE
🧪 Add tests and fix bug in flattened_updates

### DIFF
--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -292,13 +292,13 @@ def workflow_file_plans() -> list[dict[str, Any]]:
 def flattened_updates(plans: list[dict[str, Any]]) -> list[dict[str, str]]:
     return [
         {
-            "file": item["file"],
+            "file": plan.get("path", ""),
             "action": item["action"],
             "current": item["current"],
             "target": item["target"],
         }
         for plan in plans
-        for item in plan["replacements"]
+        for item in plan.get("replacements", [])
     ]
 
 

--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -5,7 +5,7 @@ from typing import Any
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.github/scripts"))
 )
-from repository_automation_tasks import configured_commands
+from repository_automation_tasks import configured_commands, flattened_updates
 
 
 def test_configured_commands_all_keys():
@@ -64,3 +64,94 @@ def test_configured_commands_extra_keys():
     result = configured_commands(section)
     assert len(result) == 1
     assert result[0] == ("command", {"name": "cmd1", "run": "c1"})
+
+def test_flattened_updates_empty():
+    """Test that flattened_updates handles empty inputs."""
+    assert flattened_updates([]) == []
+
+def test_flattened_updates_basic():
+    """Test that flattened_updates extracts standard replacements correctly."""
+    plans = [
+        {
+            "path": ".github/workflows/ci.yml",
+            "text": "...",
+            "replacements": [
+                {
+                    "action": "actions/checkout",
+                    "current": "v2",
+                    "target": "v3"
+                },
+                {
+                    "action": "actions/setup-python",
+                    "current": "v4",
+                    "target": "v5"
+                }
+            ]
+        },
+        {
+            "path": ".github/workflows/deploy.yml",
+            "text": "...",
+            "replacements": [
+                {
+                    "action": "actions/checkout",
+                    "current": "v2",
+                    "target": "v4"
+                }
+            ]
+        }
+    ]
+
+    expected = [
+        {
+            "file": ".github/workflows/ci.yml",
+            "action": "actions/checkout",
+            "current": "v2",
+            "target": "v3"
+        },
+        {
+            "file": ".github/workflows/ci.yml",
+            "action": "actions/setup-python",
+            "current": "v4",
+            "target": "v5"
+        },
+        {
+            "file": ".github/workflows/deploy.yml",
+            "action": "actions/checkout",
+            "current": "v2",
+            "target": "v4"
+        }
+    ]
+    assert flattened_updates(plans) == expected
+
+def test_flattened_updates_missing_replacements():
+    """Test that flattened_updates handles plans missing the replacements key."""
+    plans = [
+        {
+            "path": ".github/workflows/ci.yml",
+            "text": "..."
+        }
+    ]
+    assert flattened_updates(plans) == []
+
+def test_flattened_updates_missing_path():
+    """Test that flattened_updates handles plans missing the path key gracefully."""
+    plans = [
+        {
+            "replacements": [
+                {
+                    "action": "actions/checkout",
+                    "current": "v2",
+                    "target": "v3"
+                }
+            ]
+        }
+    ]
+    expected = [
+        {
+            "file": "",
+            "action": "actions/checkout",
+            "current": "v2",
+            "target": "v3"
+        }
+    ]
+    assert flattened_updates(plans) == expected


### PR DESCRIPTION
🎯 **What:**
- Added comprehensive unit tests for `flattened_updates` in `tests/test_repository_automation_tasks.py`.
- Fixed a bug in `flattened_updates` (`.github/scripts/repository_automation_tasks.py`) where accessing `item["file"]` raised a `KeyError` and accessing `plan["replacements"]` raised a `KeyError` if a plan was missing replacements.

📊 **Coverage:**
- Empty plans: `[]`
- Plans with multiple valid replacements.
- Plans missing the `replacements` key.
- Plans where a replacement is missing the `file` (or `path`) key.

✨ **Result:**
- Test suite covers `flattened_updates` entirely, preventing `KeyError` regressions in production.

---
*PR created automatically by Jules for task [7739959491523662072](https://jules.google.com/task/7739959491523662072) started by @abhimehro*