### PR TITLE
test(automation): salvage conflicted unit tests (salvages #551/#553/#557/#558)

### DIFF
--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -292,13 +292,13 @@ def workflow_file_plans() -> list[dict[str, Any]]:
 def flattened_updates(plans: list[dict[str, Any]]) -> list[dict[str, str]]:
     return [
         {
-            "file": item["file"],
+            "file": plan.get("path", ""),
             "action": item["action"],
             "current": item["current"],
             "target": item["target"],
         }
         for plan in plans
-        for item in plan["replacements"]
+        for item in plan.get("replacements", [])
     ]
 
 

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -8,10 +9,13 @@ sys.path.insert(
 from repository_automation_common import (
     BASH_BIN,
     command_env,
+    filter_env_securely,
     is_commit_sha,
+    iso_day,
     numeric_version,
     run_shell_command,
     target_ref,
+    truncate,
 )
 
 
@@ -125,3 +129,66 @@ def test_command_env() -> None:
         env = command_env()
         assert env.get("MY_TEST_VAR") == "hello"
         assert env.get("GH_PAGER") == "cat"
+
+
+# --- Salvaged from CONFLICTING #551 / #553 / #557 (adapted to main APIs) ---
+
+
+def test_iso_day_with_value():
+    known_time = dt.datetime(2024, 10, 15, 12, 30, 45, tzinfo=dt.UTC)
+    assert iso_day(known_time) == "2024-10-15"
+
+
+@patch("repository_automation_common.now_utc")
+def test_iso_day_default(mock_now_utc):
+    mock_now_utc.return_value = dt.datetime(2023, 5, 2, 8, 15, 0, tzinfo=dt.UTC)
+    assert iso_day() == "2023-05-02"
+    mock_now_utc.assert_called_once()
+
+
+def test_truncate() -> None:
+    assert truncate("hello", 10) == "hello"
+    exact_match = "1234567890"
+    assert truncate(exact_match, 10) == exact_match
+    long_text = "This is a very long text that needs to be truncated"
+    truncated = truncate(long_text, 20)
+    # Implementation: text[: limit - 15] + "\n... [truncated]"
+    assert truncated == long_text[: 20 - 15] + "\n... [truncated]"
+    assert truncated.endswith("\n... [truncated]")
+    assert len(truncated) < len(long_text)
+
+
+def test_filter_env_securely():
+    base_env = {
+        "PATH": "/usr/bin",
+        "HOME": "/home/user",
+        "GITHUB_WORKSPACE": "/workspace",
+        "UNSAFE_VAR": "secret_data",
+        "MY_TOKEN": "DUMMY_VALUE_1",
+        "RANDOM_PASSWORD": "DUMMY_VALUE_2",
+        "AWS_SECRET_KEY": "DUMMY_VALUE_3",
+        "GITHUB_SECRET": "should_be_stripped",
+        "GITHUB_PASSWORD": "dummy",
+        "GITHUB_KEY": "dummy",
+    }
+    custom_env = {
+        "MY_CUSTOM_VAR": "custom_value",
+        "GH_TOKEN": "should_be_stripped",
+        "GITHUB_TOKEN": "should_be_stripped_too",
+    }
+
+    result = filter_env_securely(base_env, custom_env)
+
+    assert result.get("PATH") == "/usr/bin"
+    assert result.get("HOME") == "/home/user"
+    assert result.get("GITHUB_WORKSPACE") == "/workspace"
+    assert "UNSAFE_VAR" not in result
+    assert "MY_TOKEN" not in result
+    assert "RANDOM_PASSWORD" not in result
+    assert "AWS_SECRET_KEY" not in result
+    assert "GITHUB_SECRET" not in result
+    assert "GITHUB_PASSWORD" not in result
+    assert "GITHUB_KEY" not in result
+    assert result.get("MY_CUSTOM_VAR") == "custom_value"
+    assert "GH_TOKEN" not in result
+    assert "GITHUB_TOKEN" not in result

--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -5,7 +5,7 @@ from typing import Any
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.github/scripts"))
 )
-from repository_automation_tasks import configured_commands
+from repository_automation_tasks import configured_commands, flattened_updates
 
 
 def test_configured_commands_all_keys():
@@ -96,3 +96,68 @@ def test_render_entry_section_with_entries():
         ""
     ]
     assert result == expected
+
+
+# --- Salvaged from CONFLICTING #558 (adapted + source fix for path/replacements) ---
+
+
+def test_flattened_updates_empty():
+    assert flattened_updates([]) == []
+
+
+def test_flattened_updates_basic():
+    plans = [
+        {
+            "path": ".github/workflows/ci.yml",
+            "text": "...",
+            "replacements": [
+                {
+                    "action": "actions/checkout",
+                    "current": "v2",
+                    "target": "v3",
+                },
+                {
+                    "action": "actions/setup-python",
+                    "current": "v4",
+                    "target": "v5",
+                },
+            ],
+        },
+        {
+            "path": ".github/workflows/deploy.yml",
+            "text": "...",
+            "replacements": [
+                {
+                    "action": "actions/checkout",
+                    "current": "v3",
+                    "target": "v4",
+                },
+            ],
+        },
+    ]
+    expected = [
+        {
+            "file": ".github/workflows/ci.yml",
+            "action": "actions/checkout",
+            "current": "v2",
+            "target": "v3",
+        },
+        {
+            "file": ".github/workflows/ci.yml",
+            "action": "actions/setup-python",
+            "current": "v4",
+            "target": "v5",
+        },
+        {
+            "file": ".github/workflows/deploy.yml",
+            "action": "actions/checkout",
+            "current": "v3",
+            "target": "v4",
+        },
+    ]
+    assert flattened_updates(plans) == expected
+
+
+def test_flattened_updates_missing_replacements():
+    plans = [{"path": ".github/workflows/ci.yml", "text": "..."}]
+    assert flattened_updates(plans) == []


### PR DESCRIPTION
## Summary
Surgical Phase 2 salvage of CONFLICTING Jules test PRs onto current `main`:

| Old | Residual kept |
|-----|----------------|
| [#551](https://github.com/abhimehro/Seatek_Analysis/pull/551) | `iso_day` tests |
| [#553](https://github.com/abhimehro/Seatek_Analysis/pull/553) | `truncate` tests (assertion adapted to `limit-15` impl) |
| [#557](https://github.com/abhimehro/Seatek_Analysis/pull/557) | `filter_env_securely` allowlist/heuristic tests |
| [#558](https://github.com/abhimehro/Seatek_Analysis/pull/558) | `flattened_updates` uses `plan.path` + safe `.get(\"replacements\")` + tests |

## Deferred (not in this draft)
- [#552](https://github.com/abhimehro/Seatek_Analysis/pull/552) — injection harden **ESCALATE**
- [#554](https://github.com/abhimehro/Seatek_Analysis/pull/554) / [#563](https://github.com/abhimehro/Seatek_Analysis/pull/563) — API rename redesigns needing dedicated human design

## Verify
```bash
python3 -m pytest tests/test_repository_automation_common.py tests/test_repository_automation_tasks.py -v
```
20 passed locally.

## ELIR
- PURPOSE: Recover valuable tests blocked by merge conflicts after Phase 1 automation merges.
- SECURITY: filter_env tests lock allowlist/heuristic behavior; no auth changes.
- FAILS IF: `flattened_updates` callers relied on per-item `file` keys instead of plan `path`.
- VERIFY: pytest command above.
- MAINTAIN: Prefer one salvage draft over rebasing each Jules twin (0es).

Phase 2 draft — human merge only (S1).