### PR TITLE
fix(security): list-only run_shell_command (salvages #552)

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -176,22 +176,18 @@ def run_process(
 
 
 def run_shell_command(
-    command: str | list[str],
+    command: list[str],
     timeout: int = 1800,
     custom_env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     safe_env = filter_env_securely(command_env(), custom_env)
 
-    # Allow backward compatibility for existing command string configurations while we migrate,
-    # but the primary path relies on lists of arguments to avoid shell injection.
     if isinstance(command, str):
-        # We still need to support strings during migration, so we run them via bash
-        cmd_args = [BASH_BIN, "-c", command]
-        cmd_str = command
-    else:
-        # Secure execution without shell wrapper
-        cmd_args = command
-        cmd_str = " ".join(command)
+        raise ValueError("command must be a list of arguments to avoid shell injection")
+
+    # Secure execution without shell wrapper
+    cmd_args = command
+    cmd_str = " ".join(command)
 
     try:
         proc = run_process(cmd_args, timeout=timeout, env=safe_env)

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -28,16 +28,17 @@ def setup_mock_process(mock_run_process):
 
 
 @patch("repository_automation_common.run_process")
-def test_run_shell_command_string(mock_run_process):
-    setup_mock_process(mock_run_process)
+def test_run_shell_command_string_raises_value_error(mock_run_process):
+    import pytest
 
-    result = run_shell_command("echo hello")
+    with pytest.raises(
+        ValueError,
+        match="command must be a list of arguments to avoid shell injection",
+    ):
+        run_shell_command("echo hello")
 
-    # Assert that bash -c is used instead of bash -lc
-    mock_run_process.assert_called_once()
-    args = mock_run_process.call_args[0][0]
-    assert args == [BASH_BIN, "-c", "echo hello"]
-    assert result["exit_code"] == 0
+    mock_run_process.assert_not_called()
+
 
 
 @patch("repository_automation_common.run_process")
@@ -105,7 +106,7 @@ def test_run_shell_command_allowlist_and_custom(mock_run_process):
     # Ensure os.environ has some sensitive stuff for the default safe_env grab
     with patch.dict(os.environ, {"AWS_ACCESS_KEY_ID": "DUMMY_VALUE_1", "PATH": "/bin"}):
         run_shell_command(
-            "echo hello",
+            ["echo", "hello"],
             custom_env={"MY_VAR": "custom_val", "GH_TOKEN": "should_be_stripped"},
         )
 


### PR DESCRIPTION
## Summary
T1 security salvage of CONFLICTING [#552](https://github.com/abhimehro/Seatek_Analysis/pull/552): reject string `command` to `run_shell_command` (no `bash -c`), require argv list. Tests adapted (S4).

## ELIR
**PURPOSE:** Close shell-injection path from string commands in repository automation helper.
**SECURITY:** Fail-closed on `str` command; callers must pass argv lists. Trust boundary: `.github/scripts/`.
**FAILS IF:** Remaining callers still pass shell strings (grep `run_shell_command(\"`).
**VERIFY:** `python3 -m pytest tests/test_repository_automation_common.py -q` (11 passed locally).
**MAINTAIN:** Do not reintroduce `bash -c` string path.

## Tier
T1 — security-sensitive salvage — **human merge only**

Autonomous merge: **never** (Phase 2 S1).