### PR TITLE
refactor(automation): warn_on_default rename + tests (salvages #554)

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -216,6 +216,16 @@ def run_checked(command: list[str]) -> subprocess.CompletedProcess[str]:
 
 
 def warn_on_default(
+    param_name: str, used_value: str, default_value: str, context: str = ""
+) -> None:
+    if used_value == default_value:
+        msg = f"Warning: Using default value '{default_value}' for {param_name}"
+        if context:
+            msg += f" in {context}"
+        print(msg, file=sys.stderr)
+
+
+def warn_on_failure(
     tool: str, args: list[str], proc: subprocess.CompletedProcess[str]
 ) -> None:
     error_text = proc.stderr.strip() or proc.stdout.strip()
@@ -229,7 +239,7 @@ def gh_json(args: list[str], default=None):
     proc = run_process([GH_BIN, *args])
     if proc.returncode != 0:
         if default is not None:
-            warn_on_default("gh", args, proc)
+            warn_on_failure("gh", args, proc)
             return default
         raise RuntimeError(proc.stderr.strip() or proc.stdout.strip())
     output = proc.stdout.strip()
@@ -241,7 +251,7 @@ def gh_json(args: list[str], default=None):
 def gh_text(args: list[str], default: str = "") -> str:
     proc = run_process([GH_BIN, *args])
     if proc.returncode != 0:
-        warn_on_default("gh", args, proc)
+        warn_on_failure("gh", args, proc)
         return default
     return proc.stdout.strip()
 
@@ -381,7 +391,7 @@ def ensure_label_exists(spec: dict[str, str], known_labels: set[str]) -> None:
     args.extend(["--", name])
     proc = run_process(args)
     if proc.returncode != 0:
-        warn_on_default("gh", args[1:], proc)
+        warn_on_failure("gh", args[1:], proc)
         return
     known_labels.add(name)
 

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -194,3 +194,36 @@ def test_filter_env_securely():
     assert result.get("MY_CUSTOM_VAR") == "custom_value"
     assert "GH_TOKEN" not in result
     assert "GITHUB_TOKEN" not in result
+
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "used_val, context, expected_err",
+    [
+        ("default_val", "", "Warning: Using default value 'default_val' for MY_VAR\n"),
+        ("default_val", "unit-test", "Warning: Using default value 'default_val' for MY_VAR in unit-test\n"),
+        ("other", "", ""),
+    ],
+)
+def test_warn_on_default_param(used_val, context, expected_err, capsys):
+    from repository_automation_common import warn_on_default
+
+    warn_on_default("MY_VAR", used_val, "default_val", context)
+    captured = capsys.readouterr()
+    assert captured.err == expected_err
+
+
+def test_warn_on_failure_emits(capsys):
+    from repository_automation_common import warn_on_failure
+    from unittest.mock import MagicMock
+
+    proc = MagicMock()
+    proc.returncode = 1
+    proc.stderr = "boom"
+    proc.stdout = ""
+    warn_on_failure("gh", ["api"], proc)
+    err = capsys.readouterr().err
+    assert "gh" in err
+    assert "boom" in err

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -217,7 +217,7 @@ def test_warn_on_default_param(used_val, context, expected_err, capsys):
 
 def test_warn_on_failure_emits(capsys):
     from repository_automation_common import warn_on_failure
-    from unittest.mock import MagicMock
+    # MagicMock imported at module scope
 
     proc = MagicMock()
     proc.returncode = 1


### PR DESCRIPTION
## Summary
Salvages DIRTY [#554](https://github.com/abhimehro/Seatek_Analysis/pull/554) onto current `main`.

- Rename misnamed `warn_on_default(tool, args, proc)` → `warn_on_failure(...)`
- Add real `warn_on_default(param_name, used_value, default_value, context=\"\")`
- Add focused unit tests (desloped; no duplicate `test_run_shell_command_list` from original)

**Note:** Open CLEAN [#571](https://github.com/abhimehro/Seatek_Analysis/pull/571) also touches `repository_automation_common.py` (list-only shell). Prefer merge #571 first, then sync this draft if needed.

## ELIR
PURPOSE: Fix misleading helper naming and cover default-value warnings.
SECURITY: Logging/helpers only; does not widen shell allowlist.
FAILS IF: External callers still import old warn_on_default(tool, args, proc) signature.
VERIFY: `PYTHONPATH=.github/scripts python3 -m pytest tests/test_repository_automation_common.py -q`
MAINTAIN: Close #554 after human merge; rebase if #571 lands first.

Autonomous merge: **none** (S1).