### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Path Hijacking Vulnerability

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -24,7 +24,7 @@ BASH_BIN = shutil.which("bash")
 if not BASH_BIN:
     raise RuntimeError("bash executable not found in PATH")
 
-GH_BIN = shutil.which("gh") or "gh"
+GH_BIN = shutil.which("gh")
 if not GH_BIN:
     raise RuntimeError("gh executable not found in PATH")
 

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -212,3 +212,8 @@ that a file is a regular file using `os.path.isfile()` or
 `stat.S_ISREG(os.stat(path).st_mode)` before attempting to open and read its
 contents, especially in security wrappers designed to read untrusted files
 safely.
+## 2026-08-01 - [B607] Starting a process with a partial executable path (Path Hijacking Vulnerability)
+
+**Vulnerability:** The script executed system commands via `subprocess` by checking `shutil.which('binary')` but falling back to `"binary"` if it was not found (e.g., `GH_BIN = shutil.which("gh") or "gh"`). This makes the application vulnerable to path hijacking (where an attacker modifies the PATH environment variable to point to a malicious executable, or places one in the current working directory).
+**Learning:** Falling back to a bare executable name when `shutil.which` fails defeats the purpose of the security check and introduces unnecessary risk, especially on systems where the OS might search the current working directory first (e.g. Windows).
+**Prevention:** Always exclusively use `shutil.which("executable_name")` to resolve the absolute path of system binaries before passing them to `subprocess` functions, and raise a clear exception or fail gracefully if the absolute path cannot be resolved.


### PR DESCRIPTION
🎯 **What:**
Fixed a path hijacking vulnerability (CWE-426 / Bandit B607) in `.github/scripts/repository_automation_common.py` where `GH_BIN` was falling back to the bare string `"gh"`.

⚠️ **Risk:**
CRITICAL/HIGH. The script checked for `shutil.which("gh")`, but if it failed, it fell back to the string `"gh"` (i.e. `GH_BIN = shutil.which("gh") or "gh"`). This meant the subsequent `if not GH_BIN:` check was dead code, and the application would later blindly execute `gh`. An attacker could exploit this by placing a malicious executable named `gh` in the current working directory or modifying the PATH, leading to arbitrary code execution (Path Hijacking).

🛡️ **Solution:**
Removed the `or "gh"` fallback, enforcing that `GH_BIN` must be an absolute, securely resolved path. If `gh` is missing, the code now properly fails fast by raising a `RuntimeError` as originally intended.

---
*PR created automatically by Jules for task [1597483023214527316](https://jules.google.com/task/1597483023214527316) started by @abhimehro*