### PR TITLE
⚡ Bolt: [performance improvement] Optimize unlist overhead in data.table aggregation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -324,3 +324,8 @@ removing repeated calls and helper functions that hide the system call.
 
 **Learning:** In R's `data.table`, when calculating multiple row-wise metrics (like subsets for first N or last N rows) across many columns, iterating over column names with a direct `for` loop and pre-calculated row indices is significantly faster (avoiding `.SD` closure and redundant subsetting overhead) than using multiple `lapply(.SD, ...)` calls.
 **Action:** Replace multiple `lapply(.SD, ...)` calls with a direct `for` loop over sensor columns using pre-calculated row indices to improve performance.
+
+## 2025-05-24 - Unlist overhead with names
+
+**Learning:** In R, when using `unlist()` to flatten lists into vectors within high-frequency loops or grouped `data.table` aggregations, inherently constructing and assigning names causes significant memory and string manipulation overhead.
+**Action:** When the resulting names of an unlisted vector are not required for downstream logic, explicitly pass `use.names = FALSE` to `unlist()`. This significantly reduces memory allocation overhead.

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -351,7 +351,11 @@ calculate_summary_stats <- function(results) {
   }
 
   summary_wide <- all_stats_dt[,
-    unlist(unname(lapply(.SD, calc_stats)), recursive = FALSE),
+    unlist(
+      unname(lapply(.SD, calc_stats)),
+      recursive = FALSE,
+      use.names = FALSE
+    ),
     keyby = "Sensor", .SDcols = metrics
   ]
 


### PR DESCRIPTION
🎯 **Why:** When flattening lists using `unlist()`, R inherently constructs and assigns names to each element, which causes string manipulation and memory overhead in hot loops (like data.table `.SD` aggregations). Since downstream code immediately overwrites these names using `setnames()`, the name generation is redundant.

💡 **What:** Added `use.names = FALSE` to the `unlist` call inside `calculate_summary_stats` in `Updated_Seatek_Analysis.R`. Also broke the line to adhere to 80-character line length limits.

📊 **Impact:** Reduces memory allocation and string manipulation overhead during grouped `data.table` aggregations, speeding up the summary statistics computation.

🔬 **Measurement:** The `test_perf.R` benchmark script showed significant improvements for `data.table` `.SDcols` operations when `use.names=FALSE` is applied, lowering execution time and memory allocations.

═════ ELIR ═════
PURPOSE: Disables redundant name generation when flattening lists during data.table aggregations.
SECURITY: N/A - performance micro-optimization.
FAILS IF: Downstream code expects the intermediate unlisted object to retain its semantic names before `setnames()` is applied.
VERIFY: Ensured `setnames` correctly overwrites the columns by position in the very next step.
MAINTAIN: When unlisting lists where names will be manually assigned later, use `use.names = FALSE` to avoid overhead.

---
*PR created automatically by Jules for task [457846583711361740](https://jules.google.com/task/457846583711361740) started by @abhimehro*