### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Hijacking Vulnerability in subprocess execution

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -24,7 +24,7 @@ BASH_BIN = shutil.which("bash")
 if not BASH_BIN:
     raise RuntimeError("bash executable not found in PATH")
 
-GH_BIN = shutil.which("gh") or "gh"
+GH_BIN = shutil.which("gh")
 if not GH_BIN:
     raise RuntimeError("gh executable not found in PATH")
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path Hijacking Vulnerability via Subprocess fallback. The variable `GH_BIN` was initialized using `shutil.which("gh") or "gh"`. If the `gh` binary was not found in the sanitized path, it fell back to the string literal `"gh"`. This fallback bypassed the null-check immediately following it and would be passed to `subprocess.run()`, making the execution vulnerable to path hijacking (where an attacker modifies the PATH or places a malicious executable named "gh" in a targeted directory).
🎯 **Impact:** An attacker could execute arbitrary code with the privileges of the automation script if the intended `gh` binary was unavailable.
🔧 **Fix:** Removed the `or "gh"` fallback. The script now correctly returns `None` if the absolute path cannot be resolved, triggering the `RuntimeError` on the next line and failing securely.
✅ **Verification:** Verified by running the test suite (`test_repository_automation_common.py` and others), and all tests passed cleanly.

═════ ELIR ═════
PURPOSE: Fix a path hijacking vulnerability by removing a fallback bare literal when resolving the GitHub CLI path.
SECURITY: Prevents untrusted relative binary execution if the required binary is missing from the explicit PATH.
FAILS IF: The binary is not found (which is the intended secure behavior).
VERIFY: Ensure the tests still pass and the RuntimeError is correctly thrown if `gh` is missing.
MAINTAIN: Always use absolute paths from `shutil.which` without falling back to string literals for subprocess calls.

---
*PR created automatically by Jules for task [14698037217228564841](https://jules.google.com/task/14698037217228564841) started by @abhimehro*