### PR TITLE
fix(env): install R 4.3.3 from Posit signed r-builds apt repo

### DIFF
--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -1,20 +1,25 @@
 # https://docs.devin.ai/onboard-devin/environment-yaml
 initialize: |
-  # Add CRAN apt repository and install R 4.3.3 with required build libraries.
+  # Install R 4.3.3 and build dependencies. CRAN's Ubuntu archive only keeps the
+  # current R release, so use Posit's r-builds .deb for the pinned version and
+  # symlink R/Rscript into /usr/local/bin.
+  export DEBIAN_FRONTEND=noninteractive
   sudo apt-get update -qq
-  sudo apt-get install -y -qq curl gnupg ca-certificates software-properties-common
-  curl -fsSL https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/cran.gpg
-  printf 'deb [signed-by=/usr/share/keyrings/cran.gpg] https://cloud.r-project.org/bin/linux/ubuntu %s-cran40/\n' "$(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/cran.list
+  sudo apt-get install -y -qq curl gnupg ca-certificates software-properties-common \
+    libcurl4-openssl-dev libxml2-dev libssl-dev \
+    libfontconfig1-dev libharfbuzz-dev libfribidi-dev libuv1-dev \
+    libzip-dev zlib1g-dev libgit2-dev pandoc cmake
   # deadsnakes PPA provides python3.12 on Ubuntu 22.04; tolerated if unavailable.
   sudo add-apt-repository -y ppa:deadsnakes/ppa || true
   sudo apt-get update -qq
-  sudo apt-get install -y -qq libcurl4-openssl-dev libxml2-dev libssl-dev \
-    libfontconfig1-dev libharfbuzz-dev libfribidi-dev libuv1-dev \
-    libzip-dev zlib1g-dev libgit2-dev pandoc cmake
-  sudo apt-get install -y -qq 'r-base=4.3.3*' 'r-base-core=4.3.3*' \
-    'r-recommended=4.3.3*' 'r-base-dev=4.3.3*'
-  # Python 3.11/3.12 is preferred for the Series 27 venv; tolerate absence.
   sudo apt-get install -y -qq python3.12 python3.12-venv python3-pip || true
+  # Posit r-builds: fixed R 4.3.3 binary for Ubuntu 22.04.
+  R_DEB="r-4.3.3_1_$(dpkg --print-architecture).deb"
+  curl -fsSL "https://cdn.posit.co/r/ubuntu-2204/pkgs/${R_DEB}" -o "/tmp/${R_DEB}"
+  sudo apt-get install -y --no-install-recommends "/tmp/${R_DEB}"
+  rm -f "/tmp/${R_DEB}"
+  sudo ln -sf /opt/R/4.3.3/bin/R /usr/local/bin/R
+  sudo ln -sf /opt/R/4.3.3/bin/Rscript /usr/local/bin/Rscript
 maintenance: |
   # Install renv into the project library and restore packages from renv.lock using Posit PPM binaries.
   Rscript --no-init-file -e 'lib <- file.path("renv/library", paste0("R-", format(getRversion()[1, 1:2])), R.version$platform); dir.create(lib, recursive = TRUE, showWarnings = FALSE); install.packages("renv", repos = "https://packagemanager.posit.co/cran/__linux__/jammy/latest", lib = lib)'
@@ -52,4 +57,4 @@ knowledge:
       Python: ${HOME}/.venvs/seatek_series27/bin/python -m ruff check .
   - name: notes
     contents: |
-      This blueprint targets Ubuntu 22.04 (jammy) images. R 4.3.3 is pinned to match renv.lock. Posit PPM provides fast binary installs for jammy. The tracked Series_27/Analysis/venv is a macOS placeholder with broken symlinks; use ${HOME}/.venvs/seatek_series27 instead. renv may warn that microbenchmark is used but not recorded (tests/test_perf_sapply_vs_lapply.R); this is harmless.
+      This blueprint targets Ubuntu 22.04 (jammy) images. R 4.3.3 is installed from Posit r-builds to match renv.lock (CRAN's Ubuntu archive only ships the current R release). Posit PPM provides fast binary installs for jammy. The tracked Series_27/Analysis/venv is a macOS placeholder with broken symlinks; use ${HOME}/.venvs/seatek_series27 instead. renv may warn that microbenchmark is used but not recorded (tests/test_perf_sapply_vs_lapply.R); this is harmless.

--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -1,25 +1,28 @@
 # https://docs.devin.ai/onboard-devin/environment-yaml
 initialize: |
   # Install R 4.3.3 and build dependencies. CRAN's Ubuntu archive only keeps the
-  # current R release, so use Posit's r-builds .deb for the pinned version and
-  # symlink R/Rscript into /usr/local/bin.
-  export DEBIAN_FRONTEND=noninteractive
-  sudo apt-get update -qq
-  sudo apt-get install -y -qq curl gnupg ca-certificates software-properties-common \
-    libcurl4-openssl-dev libxml2-dev libssl-dev \
+  # current R release, so use Posit's signed r-builds apt repository for the
+  # pinned version and symlink R/Rscript into /usr/local/bin.
+  sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq curl gnupg ca-certificates software-properties-common \
+    build-essential gfortran libcurl4-openssl-dev libxml2-dev libssl-dev \
     libfontconfig1-dev libharfbuzz-dev libfribidi-dev libuv1-dev \
     libzip-dev zlib1g-dev libgit2-dev pandoc cmake
   # deadsnakes PPA provides python3.12 on Ubuntu 22.04; tolerated if unavailable.
-  sudo add-apt-repository -y ppa:deadsnakes/ppa || true
-  sudo apt-get update -qq
-  sudo apt-get install -y -qq python3.12 python3.12-venv python3-pip || true
-  # Posit r-builds: fixed R 4.3.3 binary for Ubuntu 22.04.
-  R_DEB="r-4.3.3_1_$(dpkg --print-architecture).deb"
-  curl -fsSL "https://cdn.posit.co/r/ubuntu-2204/pkgs/${R_DEB}" -o "/tmp/${R_DEB}"
-  sudo apt-get install -y --no-install-recommends "/tmp/${R_DEB}"
-  rm -f "/tmp/${R_DEB}"
+  sudo DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:deadsnakes/ppa || true
+  sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq python3.12 python3.12-venv python3-pip || true
+  # Posit Open r-builds repository: signed, versioned R 4.3.3 binaries for jammy.
+  curl -1sLf 'https://dl.posit.co/public/open/gpg.51C0B5BB19F92D60.key' | \
+    sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/posit-open-archive-keyring.gpg
+  printf 'deb [signed-by=/usr/share/keyrings/posit-open-archive-keyring.gpg] https://dl.posit.co/public/open/deb/ubuntu %s main\n' "$(lsb_release -cs)" | \
+    sudo tee /etc/apt/sources.list.d/posit-open.list
+  sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends r-4.3.3
   sudo ln -sf /opt/R/4.3.3/bin/R /usr/local/bin/R
   sudo ln -sf /opt/R/4.3.3/bin/Rscript /usr/local/bin/Rscript
+  R --version
+  Rscript --version
 maintenance: |
   # Install renv into the project library and restore packages from renv.lock using Posit PPM binaries.
   Rscript --no-init-file -e 'lib <- file.path("renv/library", paste0("R-", format(getRversion()[1, 1:2])), R.version$platform); dir.create(lib, recursive = TRUE, showWarnings = FALSE); install.packages("renv", repos = "https://packagemanager.posit.co/cran/__linux__/jammy/latest", lib = lib)'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,9 @@ sensor data. See `README.md` for full details.
 
 ### Non-obvious Caveats
 
-- R 4.3.3 is required (matches `renv.lock`). Ubuntu Noble's `r-base` package
-  provides this version.
+- R 4.3.3 is required (matches `renv.lock`). The `.devin/blueprint.yaml`
+  installs it from Posit's signed r-builds apt repository for Ubuntu 22.04 (jammy)
+  under `/opt/R/4.3.3` and symlinks `R`/`Rscript` into `/usr/local/bin`.
 - System libraries `libgit2-dev`, `pandoc`, `libcurl4-openssl-dev`,
   `libxml2-dev`, `libssl-dev`, `libfontconfig1-dev`, `libharfbuzz-dev`,
   `libfribidi-dev`, and `libuv1-dev` must be installed before `renv::restore()`


### PR DESCRIPTION
## Summary
The `initialize` step of the `.devin/blueprint.yaml` was failing with `E: Unable to correct problems, you have held broken packages.` because the CRAN Ubuntu archive only ships the *current* R release. Pinning `r-base=4.3.3*` pulled in `r-recommended=4.3.3*`, but the repository now contains newer `r-cran-*` packages that require `r-base-core >= 4.5/4.6`, making the pinned installation unsatisfiable.

## Change
- Remove the CRAN apt repository and the version-pinned `r-base*` apt packages.
- Install R 4.3.3 from Posit's signed `r-builds` apt repository (Posit Open on Cloudsmith), which is GPG-signed and provides architecture-appropriate binaries.
- Keep the build libraries and add `build-essential gfortran` for source-package compilation.
- Prefix all `sudo apt-get` / `sudo add-apt-repository` commands with `DEBIAN_FRONTEND=noninteractive` so the snapshot build never prompts.
- Symlink `/opt/R/4.3.3/bin/{R,Rscript}` into `/usr/local/bin` and add `R --version` / `Rscript --version` sanity checks.
- Update `AGENTS.md` so the contributor-facing docs match the new provisioning path.

## Verification
- Reproduced the original `apt` failure in the snapshot build log.
- Added the Posit Open apt repo and installed `r-4.3.3`; confirmed `/opt/R/4.3.3/bin/R --version` reports `R version 4.3.3`.
- Ran the `maintenance` `renv::restore()` flow against Posit PPM and all 38 packages installed successfully.
- Confirmed `R` and `Rscript` resolve from `/usr/local/bin` after symlinking.

Link to Devin session: https://app.devin.ai/sessions/f851064a24004a289801f8e98f20d29e
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->