### PR TITLE
🛡️ Sentinel: [security improvement] Add timeout to subprocess calls

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -212,3 +212,9 @@ that a file is a regular file using `os.path.isfile()` or
 `stat.S_ISREG(os.stat(path).st_mode)` before attempting to open and read its
 contents, especially in security wrappers designed to read untrusted files
 safely.
+
+## 2026-08-03 - [Missing Subprocess Timeout]
+
+**Vulnerability:** The `get_repo_info` function in `code_health_scanner.py` executed `git` commands using `subprocess.check_output` without specifying a `timeout` argument. If the underlying `git` command hangs (e.g., waiting for interactive input, or due to network issues if reaching out to a remote), the scanner process would hang indefinitely (Denial of Service).
+**Learning:** Subprocess calls without timeouts are inherently fragile and present a resource exhaustion risk, as they assume the external process will always return in a timely manner.
+**Prevention:** Always provide a reasonable `timeout` argument (e.g., `timeout=15`) when using blocking subprocess functions like `subprocess.run`, `subprocess.check_output`, or `subprocess.call` to ensure the parent process can recover and fail securely.

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -42,6 +42,7 @@ def get_repo_info():
             env=env,
             text=True,
             shell=False,
+            timeout=15,
         ).strip()
 
         # Parse account and project from URL
@@ -58,6 +59,7 @@ def get_repo_info():
             env=env,
             text=True,
             shell=False,
+            timeout=15,
         ).strip()
 
         return account, project, commit_hash
@@ -94,10 +96,6 @@ def read_file_safe(filepath):
             not resolved_filepath.startswith(CWD_REALPATH_PLUS_SEP)
             and resolved_filepath != CWD_REALPATH
         ):
-            return []
-
-        # SECURITY: Prevent DoS by only reading regular files.
-        if not os.path.isfile(resolved_filepath):
             return []
 
         # SECURITY: Prevent DoS by only reading regular files.


### PR DESCRIPTION
This PR addresses a medium priority security issue regarding missing timeouts in subprocess calls.

🎯 **What:** Added a `timeout=15` argument to the `subprocess.check_output` calls in `code_health_scanner.py`. Also removed an accidentally duplicated block of code checking if a file was a regular file in `read_file_safe`.
⚠️ **Risk:** Medium. If the underlying `git` command hangs (e.g., waiting for input, or due to network timeouts when communicating with the origin), the scanning script would hang indefinitely, causing a Denial of Service (resource exhaustion).
🛡️ **Solution:** Enforced a 15-second timeout on the blocking subprocess calls so they fail securely with a `subprocess.TimeoutExpired` exception instead of hanging.

Also updated `.jules/sentinel.md` with the learning. Tests and linting have passed.

---
*PR created automatically by Jules for task [3391323288759654802](https://jules.google.com/task/3391323288759654802) started by @abhimehro*