### PR TITLE
fix(env): install R 4.3.3 from Posit r-builds CDN .deb

### DIFF
--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -1,8 +1,8 @@
 # https://docs.devin.ai/onboard-devin/environment-yaml
 initialize: |
   # Install R 4.3.3 and build dependencies. CRAN's Ubuntu archive only keeps the
-  # current R release, so use Posit's signed r-builds apt repository for the
-  # pinned version and symlink R/Rscript into /usr/local/bin.
+  # current R release, so install the pinned version from Posit's r-builds CDN
+  # and symlink R/Rscript into /usr/local/bin.
   sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq
   sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq curl gnupg ca-certificates software-properties-common \
     build-essential gfortran libcurl4-openssl-dev libxml2-dev libssl-dev \
@@ -12,15 +12,15 @@ initialize: |
   sudo DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:deadsnakes/ppa || true
   sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq
   sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq python3.12 python3.12-venv python3-pip || true
-  # Posit Open r-builds repository: signed, versioned R 4.3.3 binaries for jammy.
-  curl -1sLf 'https://dl.posit.co/public/open/gpg.51C0B5BB19F92D60.key' | \
-    sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/posit-open-archive-keyring.gpg
-  printf 'deb [signed-by=/usr/share/keyrings/posit-open-archive-keyring.gpg] https://dl.posit.co/public/open/deb/ubuntu %s main\n' "$(lsb_release -cs)" | \
-    sudo tee /etc/apt/sources.list.d/posit-open.list
-  sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq
-  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends r-4.3.3
-  sudo ln -sf /opt/R/4.3.3/bin/R /usr/local/bin/R
-  sudo ln -sf /opt/R/4.3.3/bin/Rscript /usr/local/bin/Rscript
+  # Posit r-builds: download the Ubuntu 22.04 binary package and install it with apt
+  # so dependencies are resolved from Ubuntu's repositories.
+  R_VERSION=4.3.3
+  ARCH=$(dpkg --print-architecture)
+  R_DEB="r-${R_VERSION}_1_${ARCH}.deb"
+  curl -fsSL -o "/tmp/${R_DEB}" "https://cdn.posit.co/r/ubuntu-2204/pkgs/${R_DEB}"
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "/tmp/${R_DEB}"
+  sudo ln -sf /opt/R/${R_VERSION}/bin/R /usr/local/bin/R
+  sudo ln -sf /opt/R/${R_VERSION}/bin/Rscript /usr/local/bin/Rscript
   R --version
   Rscript --version
 maintenance: |

--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -1,5 +1,6 @@
 # https://docs.devin.ai/onboard-devin/environment-yaml
 initialize: |
+  set -e
   # Install R 4.3.3 and build dependencies. CRAN's Ubuntu archive only keeps the
   # current R release, so install the pinned version from Posit's r-builds CDN
   # and symlink R/Rscript into /usr/local/bin.
@@ -13,11 +14,18 @@ initialize: |
   sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq
   sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq python3.12 python3.12-venv python3-pip || true
   # Posit r-builds: download the Ubuntu 22.04 binary package and install it with apt
-  # so dependencies are resolved from Ubuntu's repositories.
+  # so dependencies are resolved from Ubuntu's repositories. SHA-256 hashes are pinned
+  # to verify the downloaded artifact before apt installs it.
   R_VERSION=4.3.3
   ARCH=$(dpkg --print-architecture)
   R_DEB="r-${R_VERSION}_1_${ARCH}.deb"
+  case "$ARCH" in
+    amd64) R_SHA256="dde20cc255a1c5627ec5ed84c8d3b24f094b4b0459b363e96c137fb98220bae5" ;;
+    arm64) R_SHA256="5349604db30056bd8b40ab32518ea002bd748bcecff9e56b0ad4415981d3776e" ;;
+    *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+  esac
   curl -fsSL -o "/tmp/${R_DEB}" "https://cdn.posit.co/r/ubuntu-2204/pkgs/${R_DEB}"
+  printf "%s  /tmp/%s\n" "$R_SHA256" "$R_DEB" | sha256sum -c -
   sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "/tmp/${R_DEB}"
   sudo ln -sf /opt/R/${R_VERSION}/bin/R /usr/local/bin/R
   sudo ln -sf /opt/R/${R_VERSION}/bin/Rscript /usr/local/bin/Rscript

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,8 @@ sensor data. See `README.md` for full details.
 ### Non-obvious Caveats
 
 - R 4.3.3 is required (matches `renv.lock`). The `.devin/blueprint.yaml`
-  installs it from Posit's signed r-builds apt repository for Ubuntu 22.04 (jammy)
-  under `/opt/R/4.3.3` and symlinks `R`/`Rscript` into `/usr/local/bin`.
+  installs it from Posit's r-builds CDN for Ubuntu 22.04 (jammy) under
+  `/opt/R/4.3.3` and symlinks `R`/`Rscript` into `/usr/local/bin`.
 - System libraries `libgit2-dev`, `pandoc`, `libcurl4-openssl-dev`,
   `libxml2-dev`, `libssl-dev`, `libfontconfig1-dev`, `libharfbuzz-dev`,
   `libfribidi-dev`, and `libuv1-dev` must be installed before `renv::restore()`


### PR DESCRIPTION
## Summary
The previous fix switched the Devin blueprint to a signed Posit apt repository, but that repository does not publish versioned `r-4.3.3` packages for Ubuntu 22.04, so snapshot builds still failed with `E: Unable to locate package r-4.3.3`.

Instead, download the official Posit r-builds `.deb` for `ubuntu-2204` and install it with `apt-get`, which resolves its dependencies from Ubuntu's repositories and installs R under `/opt/R/4.3.3`. The symlinks to `/usr/local/bin` and the `R --version` / `Rscript --version` sanity checks remain unchanged.

```yaml
initialize: |
  ...
  R_VERSION=4.3.3
  ARCH=$(dpkg --print-architecture)
  R_DEB="r-${R_VERSION}_1_${ARCH}.deb"
  curl -fsSL -o "/tmp/${R_DEB}" "https://cdn.posit.co/r/ubuntu-2204/pkgs/${R_DEB}"
  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "/tmp/${R_DEB}"
  sudo ln -sf /opt/R/${R_VERSION}/bin/R /usr/local/bin/R
  sudo ln -sf /opt/R/${R_VERSION}/bin/Rscript /usr/local/bin/Rscript
  R --version
  Rscript --version
```

Also updated `AGENTS.md` to reflect the new r-builds CDN source.

Link to Devin session: https://app.devin.ai/sessions/f851064a24004a289801f8e98f20d29e
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->