### PR TITLE
🧪 [Missing tests for load_config]

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -129,7 +129,7 @@ def iso_day(value: dt.datetime | None = None) -> str:
 
 
 def load_config() -> dict[str, Any]:
-    data = yaml.safe_load(CONFIG_PATH.read_text())
+    data = yaml.safe_load(CONFIG_PATH.read_text()) or {}
     return data.get("automation", {})
 
 

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -137,6 +137,37 @@ def test_command_env() -> None:
 # --- Salvaged from CONFLICTING #551 / #553 / #557 (adapted to main APIs) ---
 
 
+
+@patch("repository_automation_common.Path.read_text")
+def test_load_config_with_automation(mock_read_text):
+    mock_read_text.return_value = "automation:\n  enabled: true\n  key: value\n"
+    from repository_automation_common import load_config
+
+    result = load_config()
+
+    assert result == {"enabled": True, "key": "value"}
+    mock_read_text.assert_called_once()
+
+@patch("repository_automation_common.Path.read_text")
+def test_load_config_without_automation(mock_read_text):
+    mock_read_text.return_value = "other_section:\n  some_key: 123\n"
+    from repository_automation_common import load_config
+
+    result = load_config()
+
+    assert result == {}
+    mock_read_text.assert_called_once()
+
+@patch("repository_automation_common.Path.read_text")
+def test_load_config_empty_file(mock_read_text):
+    mock_read_text.return_value = ""
+    from repository_automation_common import load_config
+
+    result = load_config()
+
+    assert result == {}
+    mock_read_text.assert_called_once()
+
 def test_iso_day_with_value():
     known_time = dt.datetime(2024, 10, 15, 12, 30, 45, tzinfo=dt.UTC)
     assert iso_day(known_time) == "2024-10-15"


### PR DESCRIPTION
🎯 **What:** 
Added unit tests to `tests/test_repository_automation_common.py` to cover the `load_config` function. I also updated the source function slightly to prevent `AttributeError: 'NoneType' object has no attribute 'get'` in the event that `CONFIG_PATH.read_text()` returns an empty file (which causes `yaml.safe_load` to return `None`).

📊 **Coverage:** 
- Happy path: where `automation` section is properly defined in the YAML file.
- Fallback path: where `automation` section is missing in the YAML file.
- Empty file path: where the YAML file is empty.

✨ **Result:** 
Increased test coverage and significantly reduced the likelihood of crashes caused by empty configuration files.

---
*PR created automatically by Jules for task [6018422326217396631](https://jules.google.com/task/6018422326217396631) started by @abhimehro*