### PR TITLE
fix(ci): harden load_config empty YAML (salvages #593)

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -129,7 +129,7 @@ def iso_day(value: dt.datetime | None = None) -> str:
 
 
 def load_config() -> dict[str, Any]:
-    data = yaml.safe_load(CONFIG_PATH.read_text())
+    data = yaml.safe_load(CONFIG_PATH.read_text()) or {}
     return data.get("automation", {})
 
 

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -153,6 +153,39 @@ def test_now_utc_mocked():
         mock_datetime.now.assert_called_once_with(dt.UTC)
 
 
+
+@patch("repository_automation_common.Path.read_text")
+def test_load_config_with_automation(mock_read_text):
+    mock_read_text.return_value = "automation:\n  enabled: true\n  key: value\n"
+    from repository_automation_common import load_config
+
+    result = load_config()
+
+    assert result == {"enabled": True, "key": "value"}
+    mock_read_text.assert_called_once()
+
+
+@patch("repository_automation_common.Path.read_text")
+def test_load_config_without_automation(mock_read_text):
+    mock_read_text.return_value = "other_section:\n  some_key: 123\n"
+    from repository_automation_common import load_config
+
+    result = load_config()
+
+    assert result == {}
+    mock_read_text.assert_called_once()
+
+
+@patch("repository_automation_common.Path.read_text")
+def test_load_config_empty_file(mock_read_text):
+    mock_read_text.return_value = ""
+    from repository_automation_common import load_config
+
+    result = load_config()
+
+    assert result == {}
+    mock_read_text.assert_called_once()
+
 def test_iso_day_with_value():
     known_time = dt.datetime(2024, 10, 15, 12, 30, 45, tzinfo=dt.UTC)
     assert iso_day(known_time) == "2024-10-15"


### PR DESCRIPTION
## Summary
Salvages unique defensive fix from CONFLICTING [#593](https://github.com/abhimehro/Seatek_Analysis/pull/593): `yaml.safe_load(...) or {}` plus unit tests for `load_config`.

## ELIR
- **Purpose:** Prevent AttributeError when config YAML is empty/null.
- **Security:** No auth change; CI helper only. Does not alter `run_process` env filtering.
- **Fails if:** CONFIG_PATH unreadable (pre-existing).
- **Verify:** `python3 -m pytest tests/test_repository_automation_common.py -k load_config -q`
- **Maintain:** Keep `or {}` adjacent to safe_load; tests mock Path.read_text.

S1: draft only.