### PR TITLE
🛡️ Sentinel: [HIGH] Fix subprocess path hijacking and DoS risks

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -24,7 +24,7 @@ BASH_BIN = shutil.which("bash")
 if not BASH_BIN:
     raise RuntimeError("bash executable not found in PATH")
 
-GH_BIN = shutil.which("gh") or "gh"
+GH_BIN = shutil.which("gh")
 if not GH_BIN:
     raise RuntimeError("gh executable not found in PATH")
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ processing_warnings.log
 __pycache__/
 *.pyc
 test_venv/
+test_env/

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -212,3 +212,8 @@ that a file is a regular file using `os.path.isfile()` or
 `stat.S_ISREG(os.stat(path).st_mode)` before attempting to open and read its
 contents, especially in security wrappers designed to read untrusted files
 safely.
+
+## 2026-08-05 - Fix subprocess path hijacking and DoS risks
+**Vulnerability:** Found `shutil.which("gh") or "gh"` which causes path hijacking if `gh` isn't found. Also found missing `timeout` arguments in `subprocess.check_output` and `subprocess.run` calls, which can cause DoS if the external command hangs.
+**Learning:** `shutil.which` can return `None`, and falling back to a bare string literal reintroduces path hijacking risks. Subprocesses should always have timeouts to prevent indefinite hanging.
+**Prevention:** Remove fallback to bare string literals when using `shutil.which()`. Always specify a `timeout` argument (e.g. `timeout=15`) in `subprocess.check_output`, `subprocess.run`, or `subprocess.call` calls.

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -42,6 +42,7 @@ def get_repo_info():
             env=env,
             text=True,
             shell=False,
+            timeout=15,
         ).strip()
 
         # Parse account and project from URL
@@ -58,6 +59,7 @@ def get_repo_info():
             env=env,
             text=True,
             shell=False,
+            timeout=15,
         ).strip()
 
         return account, project, commit_hash

--- a/tests/test_refactoring_agent_workflow.py
+++ b/tests/test_refactoring_agent_workflow.py
@@ -74,6 +74,7 @@ def test_prepare_command_extracts_first_cs_agent_line_from_multiline_comment(tmp
         capture_output=True,
         shell=False,
         text=True,
+        timeout=15,
         env={
             "PATH": os.environ.get("PATH", ""),
             "HOME": str(home_dir),
@@ -116,6 +117,7 @@ def test_prepare_command_fails_when_no_cs_agent_line_present(tmp_path):
         capture_output=True,
         shell=False,
         text=True,
+        timeout=15,
         env={
             "PATH": os.environ.get("PATH", ""),
             "HOME": str(home_dir),


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Found `shutil.which("gh") or "gh"` which causes path hijacking if `gh` isn't found. Also found missing `timeout` arguments in `subprocess.check_output` and `subprocess.run` calls, which can cause DoS if the external command hangs.
🎯 Impact: An attacker could potentially achieve remote code execution by exploiting the path hijacking vulnerability, or cause a denial of service by triggering a hanging subprocess call.
🔧 Fix: Removed the fallback to a bare string literal in `shutil.which` and added a generous 15 second timeout to all blocking subprocess calls.
✅ Verification: Ran `pytest` and `bandit -r .github/scripts/ code_health_scanner.py` and everything passed.

---
*PR created automatically by Jules for task [15342885219027090443](https://jules.google.com/task/15342885219027090443) started by @abhimehro*