### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -329,3 +329,7 @@ removing repeated calls and helper functions that hide the system call.
 
 **Learning:** In R, when using `unlist()` to flatten lists into vectors within high-frequency loops or grouped `data.table` aggregations, inherently constructing and assigning names causes significant memory and string manipulation overhead.
 **Action:** When the resulting names of an unlisted vector are not required for downstream logic, explicitly pass `use.names = FALSE` to `unlist()`. This significantly reduces memory allocation overhead.
+
+## 2024-08-05 - Optimize memory allocation when sorting and subsetting data.table
+
+**Learning:** When sorting a data.table and extracting the top N rows, `dt[order(-col)][1:N]` first allocates memory to create a completely sorted copy of the entire data.table (an O(N) operation) before extracting the rows. **Action:** Apply row subsetting directly to the order index vector *before* subsetting the data table: `dt[order(-col)[1:N]]`. This avoids the expensive O(N) memory allocation and copy of the full dataset, significantly improving speed and memory efficiency.

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -409,13 +409,15 @@ export_top_sensors_summary <- function(wb, summary_df, output_file,
     "full_mean", "full_sd",
     "full_pct_nonmissing"
   )
+  # ⚡ Bolt: Subset indices order(-abs_diff)[1:top_n] *before* subsetting the data frame
+  # This avoids creating a full O(N) copy of the entire sorted dataset in memory.
   if (is.data.table(summary_df)) {
     # use get or with=FALSE to avoid no visible binding warning for
     # ..cols_to_keep
     top_sensors <-
-      summary_df[order(-abs_diff)][1:top_n, cols_to_keep, with = FALSE]
+      summary_df[order(-abs_diff)[1:top_n], cols_to_keep, with = FALSE]
   } else {
-    top_sensors <- summary_df[order(-abs_diff), ][1:top_n, cols_to_keep]
+    top_sensors <- summary_df[order(-abs_diff)[1:top_n], cols_to_keep]
   }
 
   csv_top <- sub("\\.xlsx$", "_top_sensors.csv", output_file)


### PR DESCRIPTION
💡 What: Optimized row ordering in `export_top_sensors_summary` to subset indices before subsetting the data table.
🎯 Why: Using `dt[order(...)][1:N]` creates a full sorted copy of the entire data.table before taking the top N rows, which is slow and memory-intensive. `dt[order(...)[1:N]]` only allocates memory for the final N rows.
📊 Impact: Prevents O(N) memory allocation and copy for the entire dataset, speeding up top sensors summary generation.
🔬 Measurement: Observe lower memory usage and faster execution time during the pipeline summary export phase.

---
*PR created automatically by Jules for task [18161199021665205841](https://jules.google.com/task/18161199021665205841) started by @abhimehro*