### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS risk in subprocess execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -212,3 +212,9 @@ that a file is a regular file using `os.path.isfile()` or
 `stat.S_ISREG(os.stat(path).st_mode)` before attempting to open and read its
 contents, especially in security wrappers designed to read untrusted files
 safely.
+
+## 2026-08-05 - Missing Timeout in Subprocess Execution (DoS Risk)
+
+**Vulnerability:** The `get_repo_info` function in `code_health_scanner.py` called `subprocess.check_output()` without specifying a `timeout`. If the external git commands hang indefinitely (e.g., due to network issues or blocking I/O), the scanner process would block forever, leading to a Denial of Service (DoS) condition.
+**Learning:** External processes invoked via `subprocess` can hang indefinitely for unforeseen reasons. Using blocking functions like `subprocess.run`, `subprocess.check_output`, or `subprocess.call` without a timeout leaves the application vulnerable to resource exhaustion and DoS.
+**Prevention:** Always provide a `timeout` argument (e.g., `timeout=15`) when using blocking functions from the `subprocess` module to ensure execution bounds and prevent hanging processes.

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -42,6 +42,7 @@ def get_repo_info():
             env=env,
             text=True,
             shell=False,
+            timeout=15,
         ).strip()
 
         # Parse account and project from URL
@@ -58,6 +59,7 @@ def get_repo_info():
             env=env,
             text=True,
             shell=False,
+            timeout=15,
         ).strip()
 
         return account, project, commit_hash


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing timeout configurations in `subprocess.check_output` calls inside `get_repo_info()` in `code_health_scanner.py`. If the external `git` commands hang indefinitely (e.g., due to network lookup issues or blocking I/O), the scanner process will also block indefinitely, leading to a Denial of Service (DoS) risk.
🎯 **Impact:** Potential resource exhaustion and hanging processes, preventing the health scanner from completing or freeing up system resources.
🔧 **Fix:** Added `timeout=15` to both instances of `subprocess.check_output` to ensure execution bounds and fail-fast behavior.
✅ **Verification:** Verified that the test suite still passes successfully with the new timeout parameters in place. The journal has also been updated to document this specific codebase vulnerability pattern.

---
*PR created automatically by Jules for task [10855136547397989240](https://jules.google.com/task/10855136547397989240) started by @abhimehro*