### PR TITLE
⚡ Bolt: Optimize top N data.table row subsetting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -329,3 +329,8 @@ removing repeated calls and helper functions that hide the system call.
 
 **Learning:** In R, when using `unlist()` to flatten lists into vectors within high-frequency loops or grouped `data.table` aggregations, inherently constructing and assigning names causes significant memory and string manipulation overhead.
 **Action:** When the resulting names of an unlisted vector are not required for downstream logic, explicitly pass `use.names = FALSE` to `unlist()`. This significantly reduces memory allocation overhead.
+
+## 2025-05-06 - Optimize data.table top N row subsetting
+
+**Learning:** In `data.table`, when extracting the top N rows based on an ordered column, applying the row subsetting directly to the order index (e.g., `dt[order(-col)[1:N], ...]`) rather than subsetting the sorted data table (e.g., `dt[order(-col)][1:N, ...]`) prevents allocating memory for a full O(N) copy of the sorted dataset.
+**Action:** Always apply subset indices to the `order()` function's output rather than the sorted `data.table` object when extracting top N records.

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -412,10 +412,12 @@ export_top_sensors_summary <- function(wb, summary_df, output_file,
   if (is.data.table(summary_df)) {
     # use get or with=FALSE to avoid no visible binding warning for
     # ..cols_to_keep
+    # ⚡ Bolt: Apply row subsetting directly to the order index to prevent
+    # allocating memory for a full O(N) copy of the sorted dataset.
     top_sensors <-
-      summary_df[order(-abs_diff)][1:top_n, cols_to_keep, with = FALSE]
+      summary_df[order(-abs_diff)[1:top_n], cols_to_keep, with = FALSE]
   } else {
-    top_sensors <- summary_df[order(-abs_diff), ][1:top_n, cols_to_keep]
+    top_sensors <- summary_df[order(-abs_diff)[1:top_n], cols_to_keep]
   }
 
   csv_top <- sub("\\.xlsx$", "_top_sensors.csv", output_file)


### PR DESCRIPTION
💡 What: Modified the `data.table` subsetting logic in `export_top_sensors_summary` to apply the `[1:top_n]` indexing directly to the `order()` function's output rather than sorting the entire `data.table` and subsetting the materialized copy.

🎯 Why: In R's `data.table`, when extracting the top N rows based on an ordered column, applying the row subsetting directly to the order index (e.g., `dt[order(-col)[1:N], ...]`) prevents allocating memory for a full O(N) copy of the sorted dataset.

📊 Impact: Significantly reduces peak memory allocation and execution time when generating the top sensors summary, particularly as the number of tracked sensors (rows) scales up.

🔬 Measurement: Verified functionality by executing the full `testthat` suite, ensuring exact equivalence. A localized benchmark (deleted before commit) confirmed the O(N) memory allocation was successfully bypassed. Added a journal entry to `.jules/bolt.md` documenting this `data.table` optimization pattern for future use.

---
*PR created automatically by Jules for task [4183952257931892153](https://jules.google.com/task/4183952257931892153) started by @abhimehro*