### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability in subprocess execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -212,3 +212,8 @@ that a file is a regular file using `os.path.isfile()` or
 `stat.S_ISREG(os.stat(path).st_mode)` before attempting to open and read its
 contents, especially in security wrappers designed to read untrusted files
 safely.
+
+## 2026-08-05 - [Missing subprocess timeout causing DoS risk]
+**Vulnerability:** The `get_repo_info` function in `code_health_scanner.py` called `subprocess.check_output()` to execute `git remote get-url origin` and `git rev-parse HEAD` without a `timeout` argument. If the underlying `git` process hangs or takes an unexpectedly long time, this function blocks indefinitely, causing a Denial of Service (DoS) in the script.
+**Learning:** Subprocess calls without timeouts present a DoS risk if the external command hangs, blocking the main thread execution.
+**Prevention:** Always provide a `timeout` argument (e.g., `timeout=15`) when using blocking functions like `subprocess.check_output`, `subprocess.run`, or `subprocess.call` to ensure the process fails gracefully if it hangs.

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -42,6 +42,7 @@ def get_repo_info():
             env=env,
             text=True,
             shell=False,
+            timeout=15,
         ).strip()
 
         # Parse account and project from URL
@@ -58,6 +59,7 @@ def get_repo_info():
             env=env,
             text=True,
             shell=False,
+            timeout=15,
         ).strip()
 
         return account, project, commit_hash


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `get_repo_info` function executed `subprocess.check_output()` to run `git` commands without a `timeout` argument.
🎯 Impact: If the underlying `git` process hangs or takes an unexpectedly long time, this function would block the main thread indefinitely, causing a Denial of Service (DoS) in the scanner execution.
🔧 Fix: Added `timeout=15` to both `subprocess.check_output()` calls to ensure they fail safely with a `TimeoutExpired` exception if they block.
✅ Verification: Ran the Python test suite (`test_code_health_scanner.py`), which all passed successfully, ensuring no existing functionality was broken by this safe fallback addition. Checked that `.jules/sentinel.md` journal was updated with the critical learning.

---
*PR created automatically by Jules for task [11914338749867222588](https://jules.google.com/task/11914338749867222588) started by @abhimehro*