### PR TITLE
⚡ Bolt: Optimize redundant POSIXct timestamp parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -339,3 +339,7 @@ removing repeated calls and helper functions that hide the system call.
 
 **Learning:** In high-frequency R loops accessing dataframe columns (like `df[[col_name]]`) and calling generic methods (`mean()`), the standard evaluation incurs significant S3 method dispatch overhead. Using `.subset2(df, col_name)` avoids the `[[.data.frame` method lookup, and `mean.default()` bypasses the `mean()` generic dispatcher.
 **Action:** When extracting dataframe columns and computing simple vectors inside performance-critical, highly-iterative loops, use `.subset2(df, col_name)` over `[[` and call the default underlying methods (like `mean.default()`) directly to achieve a measurable execution speedup without losing code readability.
+
+## 2025-05-06 - Avoid redundant datetime conversions after data.table::fread
+**Learning:** In R, when a function like `fread` might automatically parse datetime columns to `POSIXct` objects, unconditionally applying `as.numeric()` and `as.POSIXct()` introduces a significant O(N) allocation overhead for redundant conversions.
+**Action:** Use `.subset2(dt, "Column")` to quickly extract the column and check `inherits(col, "POSIXct")` before applying redundant type conversions.

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -115,11 +115,15 @@ read_sensor_data <- function(file_path,
   # Convert timestamp if numeric
   # ⚡ Bolt: Prevent redundant memory allocations and full traversals
   # by using anyNA and reusing the parsed numeric timestamp vector
-  # instead of calling as.numeric twice
-  num_ts <- suppressWarnings(as.numeric(dt$Timestamp))
-  if (!anyNA(num_ts)) {
-    # ⚡ Bolt: Specifying tz="UTC" prevents the system timezone lookup overhead
-    dt[, "Timestamp" := as.POSIXct(num_ts, origin = "1970-01-01", tz = "UTC")] # nolint: object_name_linter
+  # instead of calling as.numeric twice. Also, check if it's already POSIXct
+  # because fread might auto-parse it.
+  ts_col <- .subset2(dt, "Timestamp")
+  if (!inherits(ts_col, "POSIXct")) {
+    num_ts <- suppressWarnings(as.numeric(ts_col))
+    if (!anyNA(num_ts)) {
+      # ⚡ Bolt: Specifying tz="UTC" prevents the system timezone lookup overhead
+      dt[, "Timestamp" := as.POSIXct(num_ts, origin = "1970-01-01", tz = "UTC")] # nolint: object_name_linter
+    }
   }
   dt
 }


### PR DESCRIPTION
💡 **What:** Added a check to avoid redundant type conversions of the Timestamp column if `data.table::fread` has already parsed it as `POSIXct`. Replaced the standard evaluation access (`$`) with `.subset2(dt, "Timestamp")` for faster column extraction.

🎯 **Why:** Unconditionally coercing a vector that has already been correctly typed by `fread` introduces significant O(N) memory allocation and processing overhead, especially for large datasets.

📊 **Impact:** Reduces processing time during the initial read step by avoiding redundant data frame traversals and vector coercions in large data files.

🔬 **Measurement:** Run the standard test suite to ensure the time parsing functionality correctly identifies POSIXct objects vs character/numeric types without introducing regressions.

---
*PR created automatically by Jules for task [2539682926599345431](https://jules.google.com/task/2539682926599345431) started by @abhimehro*