### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Bandit B607 Path Hijacking vulnerability

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -24,7 +24,8 @@ BASH_BIN = shutil.which("bash")
 if not BASH_BIN:
     raise RuntimeError("bash executable not found in PATH")
 
-GH_BIN = shutil.which("gh") or "gh"
+# SECURITY: Removed fallback to "gh" to prevent Bandit B607 path hijacking vulnerability
+GH_BIN = shutil.which("gh")
 if not GH_BIN:
     raise RuntimeError("gh executable not found in PATH")
 

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -212,3 +212,7 @@ that a file is a regular file using `os.path.isfile()` or
 `stat.S_ISREG(os.stat(path).st_mode)` before attempting to open and read its
 contents, especially in security wrappers designed to read untrusted files
 safely.
+## 2025-08-07 - Insecure Subprocess Fallback (Bandit B607)
+**Vulnerability:** The GitHub CLI path resolution (`GH_BIN = shutil.which("gh") or "gh"`) fell back to a bare string literal if the executable was not found.
+**Learning:** This fallback re-introduces the Bandit B607 path hijacking vulnerability because it allows a downstream `subprocess` call to execute a partial path (`"gh"`) which can be manipulated via the local environment.
+**Prevention:** Always rely strictly on the absolute path returned by `shutil.which()`. If the executable is missing, fail securely and explicitly rather than falling back to a bare string.

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -36,12 +36,14 @@ def get_repo_info():
             return "unknown", "unknown", "unknown"
 
         # Get origin URL
+        # SECURITY: Added timeout to prevent DoS if external git command hangs
         origin_url = subprocess.check_output(  # nosec B603
             [git_bin, "remote", "get-url", "origin"],
             stderr=subprocess.DEVNULL,
             env=env,
             text=True,
             shell=False,
+            timeout=15,
         ).strip()
 
         # Parse account and project from URL
@@ -52,12 +54,14 @@ def get_repo_info():
         account, project = match.groups()
 
         # Get current commit hash
+        # SECURITY: Added timeout to prevent DoS if external git command hangs
         commit_hash = subprocess.check_output(  # nosec B603
             [git_bin, "rev-parse", "HEAD"],
             stderr=subprocess.DEVNULL,
             env=env,
             text=True,
             shell=False,
+            timeout=15,
         ).strip()
 
         return account, project, commit_hash


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Bandit B607 Path Hijacking. The fallback `GH_BIN = shutil.which("gh") or "gh"` allowed a bare string literal to be passed to `subprocess` if the `gh` executable was not found. This bypasses the absolute path protection provided by `shutil.which` and allows an attacker to hijack the executable path via local environment manipulation.
🎯 Impact: If the `gh` executable is missing, a downstream `subprocess` call could execute a malicious `gh` binary placed in the working directory or an untrusted `PATH` location.
🔧 Fix: Removed the fallback to `"gh"`. If `shutil.which("gh")` returns `None`, it now cleanly fails and raises a `RuntimeError`.
✅ Verification: Ran the test suite. All tests pass successfully and `GH_BIN` correctly resolves without the fallback.

---
*PR created automatically by Jules for task [13705965321546727477](https://jules.google.com/task/13705965321546727477) started by @abhimehro*