### PR TITLE
🛡️ Sentinel: [HIGH] Fix subprocess path hijacking vulnerability

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -24,7 +24,7 @@ BASH_BIN = shutil.which("bash")
 if not BASH_BIN:
     raise RuntimeError("bash executable not found in PATH")
 
-GH_BIN = shutil.which("gh") or "gh"
+GH_BIN = shutil.which("gh")
 if not GH_BIN:
     raise RuntimeError("gh executable not found in PATH")
 

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -212,3 +212,7 @@ that a file is a regular file using `os.path.isfile()` or
 `stat.S_ISREG(os.stat(path).st_mode)` before attempting to open and read its
 contents, especially in security wrappers designed to read untrusted files
 safely.
+## 2025-07-11 - [B607] Starting a process with a partial executable path (Path Hijacking Vulnerability)
+**Vulnerability:** The script executed system commands via `subprocess` by checking `shutil.which('binary')` but falling back to `"binary"` if it was not found (e.g., `GH_BIN = shutil.which("gh") or "gh"`). This makes the application vulnerable to path hijacking (where an attacker modifies the PATH environment variable to point to a malicious executable, or places one in the current working directory).
+**Learning:** Falling back to a bare executable name when `shutil.which` fails defeats the purpose of the security check and introduces unnecessary risk, especially on systems where the OS might search the current working directory first (e.g. Windows).
+**Prevention:** Always exclusively use `shutil.which("executable_name")` to resolve the absolute path of system binaries before passing them to `subprocess` functions, and raise a clear exception or fail gracefully if the absolute path cannot be resolved.


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The script executed system commands via `subprocess` by checking `shutil.which('gh')` but falling back to `"gh"` if it was not found (e.g., `GH_BIN = shutil.which("gh") or "gh"`). This makes the application vulnerable to path hijacking (where an attacker modifies the PATH environment variable to point to a malicious executable, or places one in the current working directory).
🎯 Impact: This defeats the purpose of the security check and introduces unnecessary risk, especially on systems where the OS might search the current working directory first (e.g. Windows).
🔧 Fix: Removed `or "gh"` and rely exclusively on `shutil.which("gh")`.
✅ Verification: Ran Python and R tests to ensure the fallback removal did not cause test regressions.

---
*PR created automatically by Jules for task [13258595550554261570](https://jules.google.com/task/13258595550554261570) started by @abhimehro*