### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix path hijacking vulnerability in GH_BIN resolution

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -24,7 +24,7 @@ BASH_BIN = shutil.which("bash")
 if not BASH_BIN:
     raise RuntimeError("bash executable not found in PATH")
 
-GH_BIN = shutil.which("gh") or "gh"
+GH_BIN = shutil.which("gh")
 if not GH_BIN:
     raise RuntimeError("gh executable not found in PATH")
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: When resolving the `gh` binary path in `repository_automation_common.py`, the fallback `or "gh"` was used if `shutil.which` failed to find an absolute path. This bypasses the immediate safety check and defers the failure. In certain environments (particularly Windows), falling back to executing an unqualified `"gh"` command could lead to executing a malicious binary if one was placed in the Current Working Directory (CWD hijacking / Bandit B607).
🎯 Impact: Path hijacking leading to execution of a malicious binary instead of the GitHub CLI.
🔧 Fix: Removed the `or "gh"` fallback, ensuring we fail fast and securely with a `RuntimeError` if the GitHub CLI is not properly installed and in the system `PATH`. This aligns the `gh` resolution logic with the `bash` resolution logic directly above it.
✅ Verification: Ran the Python test suite in a virtual environment (`python3 -m pytest tests/`) and confirmed all 55 tests pass without regressions.

---
*PR created automatically by Jules for task [4398490144861441556](https://jules.google.com/task/4398490144861441556) started by @abhimehro*