### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path hijacking vulnerability

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -24,7 +24,7 @@ BASH_BIN = shutil.which("bash")
 if not BASH_BIN:
     raise RuntimeError("bash executable not found in PATH")
 
-GH_BIN = shutil.which("gh") or "gh"
+GH_BIN = shutil.which("gh")
 if not GH_BIN:
     raise RuntimeError("gh executable not found in PATH")
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The script executed system commands via `subprocess` by checking `shutil.which('gh')` but falling back to `"gh"` if it was not found (e.g., `GH_BIN = shutil.which("gh") or "gh"`). This makes the application vulnerable to path hijacking where an attacker could modify the PATH to execute a malicious binary, and also broke the fail-fast check (`if not GH_BIN`).
🎯 Impact: This could allow untrusted binary execution via PATH poisoning and mask missing dependency errors on startup, causing unpredictable system failures later in the execution.
🔧 Fix: Removed the fallback to `"gh"`. The logic now exclusively uses `shutil.which("gh")` which returns the absolute path if found, or `None`, triggering the explicit error check correctly.
✅ Verification: Ensure the `gh` CLI exists (or install it via `apt-get install gh`) and verify the test suite via `pytest tests/test_repository_automation_common.py`.

═════ ELIR ═════
PURPOSE: Fix path hijacking vector by strictly enforcing absolute path resolution for GitHub CLI.
SECURITY: Prevents PATH poisoning attacks (B607) and ensures dependency failure is explicit rather than silent.
FAILS IF: The `gh` command is not installed or available on PATH.
VERIFY: Ensure standard `subprocess` execution succeeds and test suite continues to pass.
MAINTAIN: Never fall back to bare executable string names when resolving system binaries for `subprocess` execution.

---
*PR created automatically by Jules for task [11749636310166085340](https://jules.google.com/task/11749636310166085340) started by @abhimehro*