### PR TITLE
⚡ Bolt: [Performance] Pre-calculate median for mad calculations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -351,3 +351,7 @@ removing repeated calls and helper functions that hide the system call.
 ## 2025-05-06 - Avoid S3 method dispatch overhead by using data.table::set() instead of `:=` inside loops or functions
 **Learning:** In R's `data.table`, using `set(dt, j = col, value = ...)` is significantly faster than using the `:=` operator for column assignment and deletion (e.g., `set(dt, j = cols_to_drop, value = NULL)`) inside loops or functions because it avoids method dispatch overhead. Additionally, applying `is.numeric()` checks before `as.numeric()` prevents redundant O(N) memory allocations during conditional data parsing (e.g., when handling inputs from `fread`).
 **Action:** When inside loops or functions, always use `set()` instead of `:=` for data.table updates by reference. Always verify if a numeric coercion is necessary using `is.numeric()` before applying `as.numeric()` to avoid unneeded allocation overheads.
+
+## 2025-08-09 - Pre-calculate median for mad
+**Learning:** When calculating both `median()` and `mad()` sequentially, `mad()` implicitly re-calculates the median internally as its default `center` argument. Passing a pre-calculated median to `mad(x, center = pre_calculated_median)` avoids calculating the median twice.
+**Action:** When extracting median and mad sequentially, pre-calculate the median (e.g., `med <- median(x)`) and pass it as the `center` argument to `mad(x, center = med)`.

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -348,11 +348,14 @@ calculate_summary_stats <- function(results) {
         min = NA_real_, max = NA_real_, count = 0L, rollmean3 = NA_real_
       )
     } else {
+      # ⚡ Bolt: Pre-calculate the median to avoid calculating it twice
+      # (once for median and once internally as the default center in mad())
+      med <- median(v_val)
       list(
         mean      = mean(v_val),
         sd        = sd(v_val),
-        median    = median(v_val),
-        mad       = mad(v_val),
+        median    = med,
+        mad       = mad(v_val, center = med),
         min       = min(v_val),
         max       = max(v_val),
         count     = n,


### PR DESCRIPTION
💡 **What:** Modified `calc_stats` to pre-calculate the median and explicitly pass it as the `center` argument when calling `mad()`. 
🎯 **Why:** When `mad()` is called, it inherently calculates the median by default to establish its center. If `median()` is also called sequentially, this results in the same expensive median operation being computed twice.
📊 **Impact:** This optimization reduces the execution time of the summary metric aggregations significantly, specifically targeting the $O(N \log N)$ or $O(N)$ redundant median computations on numeric vectors.
🔬 **Measurement:** Microbenchmarks verify that pre-calculating the median and passing it as `mad(x, center = med)` reduces overall CPU time compared to calculating `median(x)` and `mad(x)` natively in sequence. No test failures were observed.

---
*PR created automatically by Jules for task [12153530208186397059](https://jules.google.com/task/12153530208186397059) started by @abhimehro*