### PR TITLE
🛡️ Sentinel: [HIGH] Fix path hijacking vulnerability for gh CLI tool

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -24,7 +24,7 @@ BASH_BIN = shutil.which("bash")
 if not BASH_BIN:
     raise RuntimeError("bash executable not found in PATH")
 
-GH_BIN = shutil.which("gh") or "gh"
+GH_BIN = shutil.which("gh")
 if not GH_BIN:
     raise RuntimeError("gh executable not found in PATH")
 


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:** The script executed system commands via `subprocess` by checking `shutil.which('gh')` but falling back to the partial executable path `"gh"` if it was not found (i.e., `GH_BIN = shutil.which("gh") or "gh"`). This makes the application vulnerable to path hijacking (where an attacker modifies the `PATH` environment variable to point to a malicious executable named `gh`, or places one in the current working directory). Furthermore, it completely bypassed the safety check intended to prevent execution if `gh` is missing from the system.

🎯 **Impact:** If `gh` is not explicitly installed, the fallback allows an attacker who controls the local filesystem or environment to execute arbitrary code with the privileges of the script by planting a malicious `gh` executable.

🔧 **Fix:** Removed the `or "gh"` fallback. The script now strictly resolves the absolute path using `shutil.which("gh")` and explicitly fails early via `RuntimeError` if the absolute path cannot be resolved, ensuring execution is always safe and deterministic.

✅ **Verification:** Verified that the Python test suite passes successfully. The fix was applied cleanly in under 5 lines.

---
*PR created automatically by Jules for task [17986280464438175050](https://jules.google.com/task/17986280464438175050) started by @abhimehro*