### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix path hijacking vulnerability in GitHub CLI resolution

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -24,7 +24,7 @@ BASH_BIN = shutil.which("bash")
 if not BASH_BIN:
     raise RuntimeError("bash executable not found in PATH")
 
-GH_BIN = shutil.which("gh") or "gh"
+GH_BIN = shutil.which("gh")
 if not GH_BIN:
     raise RuntimeError("gh executable not found in PATH")
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The script executed system commands via `subprocess` by checking `shutil.which('gh')` but falling back to `"gh"` if it was not found (e.g., `GH_BIN = shutil.which("gh") or "gh"`). This makes the application vulnerable to path hijacking (where an attacker modifies the PATH environment variable to point to a malicious executable named `gh`, or places one in the current working directory).
🎯 Impact: An attacker who can write a malicious file named `gh` to the current working directory or manipulate the environment could execute arbitrary code with the privileges of the script.
🔧 Fix: Removed the `or "gh"` fallback, ensuring `GH_BIN` is strictly validated as an absolute path from the system PATH before proceeding.
✅ Verification: Ran the full test suite (`pytest`) and `bandit`, ensuring no regressions and that the path hijacking SAST warning is suppressed properly.

---
*PR created automatically by Jules for task [9519462661113417953](https://jules.google.com/task/9519462661113417953) started by @abhimehro*