### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix B607 path hijacking vulnerability in gh executable resolution

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -24,7 +24,7 @@ BASH_BIN = shutil.which("bash")
 if not BASH_BIN:
     raise RuntimeError("bash executable not found in PATH")
 
-GH_BIN = shutil.which("gh") or "gh"
+GH_BIN = shutil.which("gh")
 if not GH_BIN:
     raise RuntimeError("gh executable not found in PATH")
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `GH_BIN = shutil.which("gh") or "gh"` pattern created a path hijacking risk (B607) and defeated the subsequent validation check because `"gh"` is truthy, allowing the script to proceed and potentially execute a malicious binary in the working directory.
🎯 Impact: Attackers could potentially execute arbitrary code if they planted a malicious `gh` binary in a location checked by `subprocess` before the system path.
🔧 Fix: Removed the `or "gh"` fallback, enforcing that `GH_BIN` is either a resolved absolute path or `None`, which properly triggers the intended `RuntimeError`.
✅ Verification: Ran the test suite via a dedicated testing virtual environment. Tests pass successfully, and `GH_BIN` now resolves exactly as intended.

---
*PR created automatically by Jules for task [9992258670598282068](https://jules.google.com/task/9992258670598282068) started by @abhimehro*