### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix File Read DoS in hotspot scanning

### DIFF
--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -161,6 +161,10 @@ MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 
 
 def _hotspot_line_count(path_str: str) -> int | None:
+    # SECURITY: Prevent DoS by only reading regular files.
+    # Opening special files (like FIFOs or device files) can block indefinitely.
+    if not os.path.isfile(path_str):
+        return None
     try:
         with open(path_str, "rb") as file:
             content = file.read(MAX_FILE_SIZE + 1)

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -229,3 +229,22 @@ first (e.g. Windows).
 resolve the absolute path of system binaries before passing them to `subprocess`
 functions, and raise a clear exception or fail gracefully if the absolute path
 cannot be resolved.
+
+## 2026-08-13 - [File Read DoS via Special Files in Automation Tasks]
+
+**Vulnerability:** The `_hotspot_line_count` function in `.github/scripts/repository_automation_tasks.py`
+attempted to read files using `open()` without first verifying that the file was
+a regular file. If a path pointing to a special file, such as a FIFO (named
+pipe) or device file, was passed to the function, the `open()` call or
+subsequent `read()` could block indefinitely, causing the scanner process to
+hang (Denial of Service).
+**Learning:** Checking for file existence and size is
+insufficient when interacting with untrusted file paths. Special file types can
+have blocking behaviors or infinite streams (e.g., `/dev/zero`) that circumvent
+simple size checks if the check is performed after opening the file, or if the
+metadata check doesn't identify the file type.
+**Prevention:** Always verify
+that a file is a regular file using `os.path.isfile()` or
+`stat.S_ISREG(os.stat(path).st_mode)` before attempting to open and read its
+contents, especially in security wrappers designed to read untrusted files
+safely.


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `_hotspot_line_count` function in `.github/scripts/repository_automation_tasks.py` attempted to read files using `open()` without first verifying that the file was a regular file. If a path pointing to a special file, such as a FIFO (named pipe) or device file, was passed to the function, the `open()` call or subsequent `read()` could block indefinitely, causing the scanner process to hang (Denial of Service).
🎯 Impact: Denial of Service affecting the automated pipelines and task executors.
🔧 Fix: Added a strict `os.path.isfile(path_str)` check before attempting to open the file.
✅ Verification: Ran the test suite to confirm that no regressions were introduced. Evaluated and confirmed via `Code Health Review` tools locally.

═════ ELIR ═════
PURPOSE: Prevents DoS vulnerabilities by ensuring only regular files are processed by `_hotspot_line_count`.
SECURITY: Mitigates File Read DoS via special files, restricting file I/O to regular files only.
FAILS IF: A non-regular file is accessed directly.
VERIFY: Confirm the regular file check logic.
MAINTAIN: Be careful applying this check after opening file descriptors; the check must happen prior to opening.

---
*PR created automatically by Jules for task [11534371888241660802](https://jules.google.com/task/11534371888241660802) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->