### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerabilities in file reader

### DIFF
--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -161,6 +161,14 @@ MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 
 
 def _hotspot_line_count(path_str: str) -> int | None:
+    # SECURITY: Prevent ValueError from embedded null bytes in Python 3.12+
+    if "\0" in path_str:
+        return None
+
+    # SECURITY: Prevent reading from special files (e.g., FIFOs, /dev/zero) causing DoS
+    if not os.path.isfile(path_str):
+        return None
+
     try:
         with open(path_str, "rb") as file:
             content = file.read(MAX_FILE_SIZE + 1)

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -229,3 +229,8 @@ first (e.g. Windows).
 resolve the absolute path of system binaries before passing them to `subprocess`
 functions, and raise a clear exception or fail gracefully if the absolute path
 cannot be resolved.
+
+## 2025-02-28 - [DoS Protection for File Reads]
+**Vulnerability:** File reading utility lacked checks for embedded null bytes in paths and did not verify if the path pointed to a regular file.
+**Learning:** Python 3.12+ throws `ValueError` for null bytes in paths (unlike previous versions where it might be `OSError` or silenty fail). Reading special files (like `/dev/zero` or FIFOs) using standard size limits (e.g. `read(MAX_SIZE)`) can hang or cause unexpected behavior if not explicitly checked against `os.path.isfile()`.
+**Prevention:** Always validate paths for embedded null bytes `\0` and verify the file type using `os.path.isfile()` before attempting to open untrusted paths.

--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -190,3 +190,10 @@ def test_hotspot_line_count_exceeds_max_size(monkeypatch):
         assert _hotspot_line_count(tf_path) is None
     finally:
         os.remove(tf_path)
+
+def test_hotspot_line_count_null_byte():
+    assert _hotspot_line_count("test\0.txt") is None
+
+def test_hotspot_line_count_special_file():
+    assert _hotspot_line_count("/dev/null") is None
+    assert _hotspot_line_count("/dev/zero") is None


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `_hotspot_line_count` function lacked checks for embedded null bytes in file paths and did not verify if the target was a regular file before attempting to open it.
🎯 Impact: Passing a path with a null byte in Python 3.12+ causes an unhandled `ValueError` which leads to script failure. Pointing the path at a special file (like `/dev/zero` or a FIFO) can lead to resource exhaustion or blocking hangs during file reads. Both act as a Denial of Service (DoS) mechanism.
🔧 Fix: Added explicit checks to reject paths containing `\0` and paths that do not evaluate to a regular file via `os.path.isfile()`. The function now fails securely by returning `None`.
✅ Verification: New unit tests were added for null byte behavior and special file behavior (`/dev/null`, `/dev/zero`). The full `pytest` suite passes with no regressions.

---
*PR created automatically by Jules for task [16528354413479813118](https://jules.google.com/task/16528354413479813118) started by @abhimehro*