### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix File Read DoS in repository_automation_tasks

### DIFF
--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -162,6 +162,11 @@ MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 
 def _hotspot_line_count(path_str: str) -> int | None:
     try:
+        # SECURITY: Prevent File Read DoS by only reading regular files.
+        # This prevents blocking behavior when reading special files like named pipes (FIFOs) or device files.
+        if not os.path.isfile(path_str):
+            return None
+
         with open(path_str, "rb") as file:
             content = file.read(MAX_FILE_SIZE + 1)
         if len(content) > MAX_FILE_SIZE:

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -229,3 +229,8 @@ first (e.g. Windows).
 resolve the absolute path of system binaries before passing them to `subprocess`
 functions, and raise a clear exception or fail gracefully if the absolute path
 cannot be resolved.
+
+## 2026-08-16 - [File Read DoS via Special Files in Background Tasks]
+**Vulnerability:** The `_hotspot_line_count` function in `.github/scripts/repository_automation_tasks.py` attempted to read files using `open()` without first verifying that the file was a regular file. This made it vulnerable to hanging or exhausting resources if pointed at a special file (like a named pipe/FIFO or device file) which could block indefinitely, causing a Denial of Service.
+**Learning:** Functions designed to read untrusted or dynamic file paths must explicitly check for file types. Standard length checks (e.g., checking `len(content)`) after opening or reading are insufficient to prevent blocking I/O behavior during the initial file read phase.
+**Prevention:** Always use `os.path.isfile(path)` or `stat.S_ISREG` to verify a file is a regular file before attempting to open and read its contents, even in internal automation scripts.


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `_hotspot_line_count` function in `.github/scripts/repository_automation_tasks.py` attempted to read files using `open()` without verifying if they were regular files, making it vulnerable to File Read DoS via special files (like FIFOs or `/dev/zero`) which could block execution indefinitely.
🎯 Impact: A Denial of Service (DoS) could occur if the automation script is pointed at a special file, causing the GitHub Action or CI pipeline to hang and consume resources until killed by a timeout.
🔧 Fix: Added an `os.path.isfile(path_str)` check before attempting to open the file to ensure only regular files are processed.
✅ Verification: The codebase was analyzed via Bandit and manual testing; the pytest suite passes successfully with no regressions.

---
*PR created automatically by Jules for task [8317941668706526000](https://jules.google.com/task/8317941668706526000) started by @abhimehro*