### PR TITLE
⚡ Bolt: Use mean.default() in calculate_summary_stats for performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -361,3 +361,6 @@ removing repeated calls and helper functions that hide the system call.
 
 **Learning:** To avoid redundant O(N) memory allocation and processing overhead when filtering missing values, check for the presence of NAs first using `anyNA()`. The `anyNA()` function is implemented in C and short-circuits, requiring no memory allocation.
 **Action:** When filtering missing values, use `if (anyNA(x)) x <- x[!is.na(x)]` instead of unconditionally subsetting with `!is.na(x)`.
+## 2025-05-06 - Bypassing S3 Dispatch in apply loops
+**Learning:** In high-frequency operations or internal loops (like `lapply(.SD)` in `data.table`), R's generic S3 dispatch for `mean()` introduces measurable overhead.
+**Action:** When the data type is known to be numeric and no custom class dispatch is needed, call the default method `mean.default()` directly to bypass dispatch and improve execution speed.

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -352,7 +352,8 @@ calculate_summary_stats <- function(results) {
       # argument to avoid redundant median calculations for measurable speedup.
       med <- median(v_val)
       list(
-        mean      = mean(v_val),
+        # ⚡ Bolt: Bypass generic mean() dispatch with mean.default()
+        mean      = mean.default(v_val),
         sd        = sd(v_val),
         median    = med,
         mad       = mad(v_val, center = med),


### PR DESCRIPTION
💡 What: Replaced `mean()` with `mean.default()` inside the `calculate_summary_stats` loop.
🎯 Why: In high-frequency R loops (like `lapply(.SD)`), R's generic S3 dispatch adds unnecessary overhead when we already know the vectors are numeric.
📊 Impact: Expected performance improvement in summary statistic generation for large data sets by bypassing dispatch.
🔬 Measurement: Verify tests still pass identically and measure execution time of `calculate_summary_stats` with large data frames.

---
*PR created automatically by Jules for task [11428595014562180697](https://jules.google.com/task/11428595014562180697) started by @abhimehro*