### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix File Read DoS and Null Byte crash in repository_automation_tasks

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -44,7 +44,7 @@ def _remove_heuristic_secrets(env_dict: dict[str, str]) -> None:
     sensitive_substrings = ("TOKEN", "SECRET", "KEY", "PASSWORD", "AUTH", "CRED")
     keys_to_remove = [
         k
-        for k in env_dict.keys()
+        for k in env_dict
         if any(sub in k.upper() for sub in sensitive_substrings)
     ]
     for k in keys_to_remove:

--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -162,12 +162,20 @@ MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 
 def _hotspot_line_count(path_str: str) -> int | None:
     try:
+        # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
+        if "\0" in path_str:
+            return None
+
+        # SECURITY: Prevent File Read DoS via special files (e.g. FIFOs, /dev/zero)
+        if not os.path.isfile(path_str):
+            return None
+
         with open(path_str, "rb") as file:
             content = file.read(MAX_FILE_SIZE + 1)
         if len(content) > MAX_FILE_SIZE:
             return None
         return content.count(b"\n") + 1
-    except OSError:
+    except (OSError, ValueError):
         return None
 
 
@@ -783,7 +791,7 @@ def run_daily_status_report(config: dict[str, Any]) -> dict[str, Any]:
 # ⚡ Bolt: Pre-compile regular expressions to prevent redundant pattern compilation
 # overhead on every invocation, particularly in loops over issues.
 STATUS_MARKER_PATTERN = re.compile(
-    r"<!-- repository-automation:task-status\n(.*?)\n-->", re.S
+    r"<!-- repository-automation:task-status\n(.*?)\n-->", re.DOTALL
 )
 
 

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -229,3 +229,9 @@ first (e.g. Windows).
 resolve the absolute path of system binaries before passing them to `subprocess`
 functions, and raise a clear exception or fail gracefully if the absolute path
 cannot be resolved.
+
+## 2026-08-18 - [File Read DoS and Null Byte Crash]
+
+**Vulnerability:** The `_hotspot_line_count` function in `.github/scripts/repository_automation_tasks.py` attempted to open files without checking if they were regular files, and it didn't check for embedded null bytes in paths. This could lead to a File Read DoS (if a special file like a FIFO was read) and unhandled `ValueError` exceptions (if a null byte was passed to `open()` in newer Python versions).
+**Learning:** `open()` can throw a `ValueError` for paths with null bytes and can hang if opening special files like `/dev/zero` or FIFOs. We must validate both the path contents and the file type.
+**Prevention:** Always check `if '\0' in path:` to return early or explicitly catch `ValueError`, and verify the file is a regular file using `os.path.isfile(path)` before attempting to read it.

--- a/Series_27/Analysis/outlier_analysis_series27.py
+++ b/Series_27/Analysis/outlier_analysis_series27.py
@@ -347,7 +347,7 @@ def _load_and_validate_file(input_file):
     try:
         with open(input_file, "rb") as f:
             file_buffer = f.read(MAX_FILE_SIZE + 1)
-    except IOError as e:
+    except OSError as e:
         logging.error(f"Error reading input file {input_file}: {e}")
         return None
 

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -7,7 +7,6 @@ sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.github/scripts"))
 )
 from repository_automation_common import (
-    BASH_BIN,
     _remove_heuristic_secrets,
     command_env,
     filter_env_securely,

--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -5,9 +5,13 @@ from typing import Any
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.github/scripts"))
 )
-from repository_automation_tasks import configured_commands, flattened_updates, _hotspot_line_count
-from pathlib import Path
 import tempfile
+
+from repository_automation_tasks import (
+    _hotspot_line_count,
+    configured_commands,
+    flattened_updates,
+)
 
 
 def test_configured_commands_all_keys():
@@ -173,6 +177,10 @@ def test_hotspot_line_count_not_a_file(tmp_path):
     dir_path = tmp_path / "test_dir"
     dir_path.mkdir()
     assert _hotspot_line_count(str(dir_path)) is None
+
+def test_hotspot_line_count_null_byte():
+    # Null byte should return None instead of throwing ValueError
+    assert _hotspot_line_count("test\0.txt") is None
 
 def test_hotspot_line_count_unreadable(tmp_path):
     dir_path = tmp_path / "test_dir2"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `_hotspot_line_count` function in `.github/scripts/repository_automation_tasks.py` attempted to open files without checking if they were regular files and did not check for embedded null bytes in paths. This could lead to a File Read DoS (if a special file like a FIFO was read) and unhandled `ValueError` exceptions (if a null byte was passed to `open()` in newer Python versions).
🎯 Impact: An attacker or malformed input could cause the automation process to hang indefinitely or crash due to an unhandled exception.
🔧 Fix: Added checks for `\0` in the path string, validated that the path points to a regular file using `os.path.isfile`, and updated the `except` block to catch `ValueError`. Added tests to cover these scenarios.
✅ Verification: `pytest tests/test_repository_automation_tasks.py` now includes specific test cases for null byte handling and successfully passes the entire test suite.

---
*PR created automatically by Jules for task [16433287658105719264](https://jules.google.com/task/16433287658105719264) started by @abhimehro*