### PR TITLE
fix(security): reject unsafe hotspot file reads

### DIFF
--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -161,13 +161,17 @@ MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 
 
 def _hotspot_line_count(path_str: str) -> int | None:
+    """Return a bounded line count for a regular file, or ``None`` when unsafe."""
+    if "\0" in path_str or not os.path.isfile(path_str):
+        return None
+
     try:
         with open(path_str, "rb") as file:
             content = file.read(MAX_FILE_SIZE + 1)
         if len(content) > MAX_FILE_SIZE:
             return None
         return content.count(b"\n") + 1
-    except OSError:
+    except (OSError, ValueError):
         return None
 
 

--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -190,3 +190,17 @@ def test_hotspot_line_count_exceeds_max_size(monkeypatch):
         assert _hotspot_line_count(tf_path) is None
     finally:
         os.remove(tf_path)
+
+
+def test_hotspot_line_count_rejects_null_byte_path():
+    assert _hotspot_line_count("unsafe\0path.py") is None
+
+
+def test_hotspot_line_count_rejects_fifo_without_opening(tmp_path):
+    fifo_path = tmp_path / "hotspot.fifo"
+    os.mkfifo(fifo_path)
+
+    try:
+        assert _hotspot_line_count(str(fifo_path)) is None
+    finally:
+        fifo_path.unlink(missing_ok=True)

--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -204,3 +204,17 @@ def test_hotspot_line_count_rejects_fifo_without_opening(tmp_path):
         assert _hotspot_line_count(str(fifo_path)) is None
     finally:
         fifo_path.unlink(missing_ok=True)
+
+
+def test_hotspot_line_count_handles_value_error_after_regular_file_check(
+    monkeypatch, tmp_path
+):
+    path = tmp_path / "regular.py"
+    path.write_text("print('safe')\n", encoding="utf-8")
+
+    def raise_value_error(*_args, **_kwargs):
+        raise ValueError("unexpected invalid file operation")
+
+    monkeypatch.setattr("builtins.open", raise_value_error)
+
+    assert _hotspot_line_count(str(path)) is None


### PR DESCRIPTION
## Scope

Focused replacement for the `_hotspot_line_count` hardening proposed by #688. The function rejects embedded NUL paths and non-regular files before opening them, while retaining the existing bounded read. No original PR is closed or superseded by this draft.

## Regression coverage

- An embedded NUL path returns `None` without opening a file.
- A FIFO returns `None` without blocking on an open.
- An unexpected `ValueError` from the post-validation file-open operation returns `None` without producing a line count.

## ValueError rationale

The explicit NUL-path guard prevents the ordinary NUL-path failure from reaching `open()`. The `ValueError` handler remains intentionally defensive for unexpected failures that can occur after the regular-file check, and the new regression test injects that post-check failure to ensure the scanner fails closed.

## Verification

`uv run --isolated --with pytest --with pyyaml python -m pytest tests/test_repository_automation_tasks.py -q` passed (17 tests).

## Follow-up

This remains a draft pending human security review of repository automation behavior.
