### PR TITLE
🛡️ Sentinel: [HIGH] Fix File Read DoS in _hotspot_line_count

### DIFF
--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -162,6 +162,10 @@ MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 
 def _hotspot_line_count(path_str: str) -> int | None:
     try:
+        if "\0" in path_str:
+            return None
+        if not os.path.isfile(path_str):
+            return None
         with open(path_str, "rb") as file:
             content = file.read(MAX_FILE_SIZE + 1)
         if len(content) > MAX_FILE_SIZE:

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -229,3 +229,9 @@ first (e.g. Windows).
 resolve the absolute path of system binaries before passing them to `subprocess`
 functions, and raise a clear exception or fail gracefully if the absolute path
 cannot be resolved.
+
+## 2026-08-18 - [File Read DoS via Special Files]
+
+**Vulnerability:** The `_hotspot_line_count` function in `.github/scripts/repository_automation_tasks.py` attempted to read files using `open()` without first verifying that the file was a regular file and did not contain embedded null bytes. If a path pointing to a special file, such as a FIFO (named pipe) or device file, was passed to the function, the `open()` call or subsequent `read()` could block indefinitely, causing the scanner process to hang (Denial of Service).
+**Learning:** Checking for file existence and size is insufficient when interacting with untrusted file paths. Special file types can have blocking behaviors or infinite streams (e.g., `/dev/zero`) that circumvent simple size checks if the check is performed after opening the file, or if the metadata check doesn't identify the file type. In Python 3.12+, paths with embedded null bytes also cause unhandled `ValueError`s.
+**Prevention:** Always verify that a file is a regular file using `os.path.isfile()` or `stat.S_ISREG(os.stat(path).st_mode)` and check for embedded null bytes before attempting to open and read its contents, especially in security wrappers designed to read untrusted files safely.


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `_hotspot_line_count` function opened files directly without validating if the path pointed to a regular file or contained embedded null bytes, leaving it vulnerable to unhandled `ValueError` exceptions (in Python 3.12+) or potential infinite blocking/hangs if passed a special file (e.g., a device file or named pipe).
🎯 Impact: Denial of Service (DoS). The automation script could hang indefinitely or crash if an attacker or unexpected input supplied a path to a special file or a path with null bytes.
🔧 Fix: Added explicit checks for embedded null bytes (`\0`) and enforced that the path points to a regular file (`os.path.isfile()`) before attempting to `open()` the file.
✅ Verification: Ran `pytest tests/` successfully and manually inspected the updated code to confirm early return paths correctly guard the `open()` call. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [3148207761719333110](https://jules.google.com/task/3148207761719333110) started by @abhimehro*