### PR TITLE
🎨 Palette: Improve Excel accessibility with explicit font colors

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
+## 2025-05-06 - Excel Accessibility for Background Colors
+
+**Learning:** When generating Excel reports, using background fill colors (`bgFill`) without explicitly setting a text color (`fontColour`) can result in poor contrast and accessibility issues (e.g., black text on dark colored backgrounds). **Action:** Always explicitly pair `bgFill` with a high-contrast `fontColour` (like `fontColour = "#000000"` for light backgrounds or `fontColour = "#FFFFFF"` for dark ones) when creating styles in `openxlsx` to ensure proper readability and accessibility.
 ## 2025-05-06 - CLI Input Validation Error UX
 
 **Learning:** Allowing standard library exceptions (like FileNotFoundError) to

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -544,8 +544,12 @@ dump_summary_excel <- function(results, output_file, highlight_top_n = 5) {
   # ⚡ Bolt: Hoisted style definitions out of inner functions/loops
   # to avoid recreating styles redundantly on every sheet generation.
   header_style <- createStyle(textDecoration = "bold")
-  highlight_style_yearly <- createStyle(bgFill = "#FFD700")
-  highlight_style_summary <- createStyle(bgFill = "#FF9999")
+  highlight_style_yearly <- createStyle(
+    bgFill = "#FFD700", fontColour = "#000000"
+  )
+  highlight_style_summary <- createStyle(
+    bgFill = "#FF9999", fontColour = "#000000"
+  )
 
   # Write each year's sheet
   cat("\n📊 Generating yearly summary sheets...\n")


### PR DESCRIPTION
💡 What: Added explicit `fontColour = "#000000"` to the `openxlsx::createStyle` definitions for `highlight_style_yearly` and `highlight_style_summary` in the R script.

🎯 Why: Relying on default font colors when setting a background fill (`bgFill`) can lead to unreadable text (e.g., black text on a dark background or white on white) depending on the user's Excel theme or system settings.

📸 Before/After: N/A (Backend change generating Excel files).

♿ Accessibility: Ensures that highlighted cells in the generated Excel reports have guaranteed high contrast (black text on colored backgrounds), improving readability for all users.

---
*PR created automatically by Jules for task [5970367201032691524](https://jules.google.com/task/5970367201032691524) started by @abhimehro*