### PR TITLE
salvage(): drop duplicate isfile check in code_health_scanner

### DIFF
--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -100,10 +100,6 @@ def read_file_safe(filepath):
         if not os.path.isfile(resolved_filepath):
             return []
 
-        # SECURITY: Prevent DoS by only reading regular files.
-        if not os.path.isfile(resolved_filepath):
-            return []
-
         # SECURITY: Prevent Out-Of-Memory (OOM) DoS attacks by limiting file size
         # To avoid TOCTOU vulnerability, we read up to MAX_FILE_SIZE + 1 bytes.
         with open(resolved_filepath, "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Description

Stage 2 salvage of Jules [#705](https://github.com/abhimehro/Seatek_Analysis/pull/705). Reapplied only the redundant `os.path.isfile` dedup onto current main.

- **Original PR**: https://github.com/abhimehro/Seatek_Analysis/pull/705 (left open; not rewritten)
- **Original anchors**: base `53416c3cfdb3f6929507a8747b043ffaf291e683`, head `c4d07fa12213f2c004c09f029b392a51fc81fe9f`
- **Trusted base at branch creation**: `53416c3cfdb3f6929507a8747b043ffaf291e683` (matches ledger; rechecked immediately before branch creation)
- **Changed paths**: `code_health_scanner.py` only
- **Prohibited / not carried**: `.jules/bolt.md`
- **Why original was not completed**: original also changes `.jules/bolt.md`; Stage 2 must not wholesale-checkout journals.

## Testing Instructions

**Named test** (work item `s2-20260820b-seatek-705-isfile`):

```
python3 -m py_compile code_health_scanner.py
Rscript -e "library(testthat); source('Updated_Seatek_Analysis.R', local = TRUE); testthat::test_dir('tests/testthat', reporter='summary')"
```

The work-item command omitted `source('Updated_Seatek_Analysis.R')`; current main tests require it (AGENTS.md). Result: `py_compile` OK; testthat completed with one empty-test skip and no failures after sourcing.

## Checklist

- [x] Duplicate isfile check removed once
- [x] `.jules/bolt.md` absent from salvage diff
- [x] Draft only; Stage 3 owns completion
