### PR TITLE
🛡️ Sentinel: [HIGH] Fix unhandled TypeError in null byte check (DoS risk)

### DIFF
--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -682,9 +682,9 @@ def status_icon(status: str) -> str:
 
 # ⚡ Bolt: Helper function extracted to avoid "Large Method" rule violations when
 # replacing sequential API calls with concurrent execution via ThreadPoolExecutor.
-def fetch_daily_report_data() -> (
-    tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]
-):
+def fetch_daily_report_data() -> tuple[
+    list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]
+]:
     # ⚡ Bolt: Using ThreadPoolExecutor to run independent GitHub API calls concurrently
     # significantly reduces blocking I/O time in daily_report_lines.
     with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -227,3 +227,9 @@ working directory first (e.g. Windows). **Prevention:** Always exclusively use
 `shutil.which("executable_name")` to resolve the absolute path of system
 binaries before passing them to `subprocess` functions, and raise a clear
 exception or fail gracefully if the absolute path cannot be resolved.
+
+## 2026-08-20 - [TypeError on Pathlib Null Byte Check]
+
+**Vulnerability:** The `read_file_safe` function contained a check `if "\0" in filepath:` intended to prevent a Python 3.12+ `ValueError` related to null bytes. However, when `filepath` was passed as a `pathlib.Path` object instead of a string, this check raised a `TypeError` because `Path` objects are not directly iterable as characters. This unintentional unhandled exception caused the scanner process to crash (Denial of Service).
+**Learning:** Security checks that rely on string operations (like checking for substring presence) can inadvertently cause crashes if they do not account for path-like objects (e.g., `pathlib.Path`). Type checking or coercion is necessary for robust path handling.
+**Prevention:** Always explicitly coerce variables intended for path analysis to strings (e.g., `str(filepath)`) before performing string-specific validation checks like substring searching, particularly in security wrappers that receive untrusted inputs.

--- a/Series_27/Analysis/test_outlier_analysis_series27.py
+++ b/Series_27/Analysis/test_outlier_analysis_series27.py
@@ -208,9 +208,9 @@ def test_apply_corrections_path_traversal(tmp_path):
         assert "outside_traversal_target" in filename
 
         # Defense-in-depth: resolved path must remain within output_dir
-        assert os.path.realpath(out_file).startswith(
-            os.path.realpath(output_dir)
-        ), f"Output path {out_file} escapes {output_dir}"
+        assert os.path.realpath(out_file).startswith(os.path.realpath(output_dir)), (
+            f"Output path {out_file} escapes {output_dir}"
+        )
 
         # The corrections summary should also reference the safe path
         assert not result.empty

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -84,7 +84,7 @@ def read_file_safe(filepath):
     try:
         # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
         # preventing unhandled exception DoS attacks.
-        if "\0" in filepath:
+        if "\0" in str(filepath):
             return []
 
         # SECURITY: Prevent path traversal by ensuring file is within current directory.

--- a/tests/test_pathlib_null.py
+++ b/tests/test_pathlib_null.py
@@ -1,0 +1,7 @@
+import pathlib
+from code_health_scanner import read_file_safe
+
+
+def test_pathlib_null():
+    path = pathlib.Path("test\0.txt")
+    assert read_file_safe(path) == []

--- a/tests/test_refactoring_agent_workflow.py
+++ b/tests/test_refactoring_agent_workflow.py
@@ -93,7 +93,7 @@ def test_prepare_command_extracts_first_cs_agent_line_from_multiline_comment(tmp
     )  # nosec B101
     assert "second-command-should-be-ignored" not in result.stdout  # nosec B101
     assert github_output.read_text(encoding="utf-8") == (  # nosec B101
-        "command<<EOF\n" "/cs-agent skill:fix-code-health-degradations\n" "EOF\n"
+        "command<<EOF\n/cs-agent skill:fix-code-health-degradations\nEOF\n"
     )
 
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Passing a `pathlib.Path` to `read_file_safe` causes an unhandled `TypeError` (DoS risk) because the `"\0" in filepath` check assumes a string.
🎯 Impact: A malicious or unexpected `pathlib.Path` input could bypass the intended safe exit and crash the scanner process.
🔧 Fix: Explicitly coerce `filepath` to a string (`str(filepath)`) before the null byte check.
✅ Verification: A new unit test (`test_pathlib_null.py`) confirms that passing a `Path` object with a null byte now safely returns an empty list `[]` instead of raising an exception. Tests run via `pytest`.

---
*PR created automatically by Jules for task [14415672969325371296](https://jules.google.com/task/14415672969325371296) started by @abhimehro*