### PR TITLE
⚡ Bolt: Remove redundant os.path.isfile check in code_health_scanner.py

### DIFF
--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -96,10 +96,7 @@ def read_file_safe(filepath):
         ):
             return []
 
-        # SECURITY: Prevent DoS by only reading regular files.
-        if not os.path.isfile(resolved_filepath):
-            return []
-
+        # ⚡ Bolt: Removed redundant os.path.isfile() check which introduced unnecessary file system lookup overhead.
         # SECURITY: Prevent DoS by only reading regular files.
         if not os.path.isfile(resolved_filepath):
             return []


### PR DESCRIPTION
💡 What: Removed a completely duplicate `os.path.isfile()` check inside the `read_file_safe()` function.
🎯 Why: The codebase contained an exact duplicate of the `os.path.isfile()` check right next to itself. Checking the exact same path for existence twice in a row introduces unnecessary file system lookup overhead via redundant `stat` system calls without providing any additional safety.
📊 Impact: Saves one microscopic `stat` system call on every invocation of `read_file_safe()`, slightly reducing disk I/O bound operations during whole-repository codebase scans.
🔬 Measurement: Can be verified by running `PYTHONPATH=. python3 -m pytest tests/test_code_health_scanner.py` and noting that all path-traversal/security/DoS unit tests continue to pass seamlessly.

---
*PR created automatically by Jules for task [2230789979169246661](https://jules.google.com/task/2230789979169246661) started by @abhimehro*