### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unhandled TypeError in null byte check (DoS risk)

### DIFF
--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -84,7 +84,7 @@ def read_file_safe(filepath):
     try:
         # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
         # preventing unhandled exception DoS attacks.
-        if "\0" in filepath:
+        if not filepath or "\0" in str(filepath):
             return []
 
         # SECURITY: Prevent path traversal by ensuring file is within current directory.

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -100,10 +100,6 @@ def read_file_safe(filepath):
         if not os.path.isfile(resolved_filepath):
             return []
 
-        # SECURITY: Prevent DoS by only reading regular files.
-        if not os.path.isfile(resolved_filepath):
-            return []
-
         # SECURITY: Prevent Out-Of-Memory (OOM) DoS attacks by limiting file size
         # To avoid TOCTOU vulnerability, we read up to MAX_FILE_SIZE + 1 bytes.
         with open(resolved_filepath, "r", encoding="utf-8") as f:

--- a/tests/test_code_health_scanner.py
+++ b/tests/test_code_health_scanner.py
@@ -104,6 +104,17 @@ def test_read_file_safe_null_byte():
     assert read_file_safe("test\0.txt") == []
 
 
+def test_read_file_safe_path_types():
+    from pathlib import Path
+
+    # Should safely return empty list without raising TypeError
+    assert read_file_safe(None) == []
+
+    # Should safely handle pathlib.Path objects without raising TypeError during null check
+    test_path = Path("test\0_path.txt")
+    assert read_file_safe(test_path) == []
+
+
 def test_read_file_safe_restricted_permissions():
     test_file = "test_restricted.txt"
     with open(test_file, "w") as f:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `read_file_safe` function in `code_health_scanner.py` checked `if "\0" in filepath:`. If `filepath` is provided as a `pathlib.Path` object or `None`, this check raises an unhandled `TypeError` (e.g., `argument of type 'PosixPath' is not iterable`), which could be exploited for a Denial of Service (DoS) attack if the scanner processes uncontrolled inputs.
🎯 Impact: An attacker could crash the scanner or application by providing crafted inputs that cause paths to be passed as `None` or `pathlib.Path` objects to the file reading utility.
🔧 Fix: Updated the check to `if not filepath or "\0" in str(filepath):`. This ensures that `None` returns an empty list safely, and `Path` objects are correctly cast to strings before the null byte check is performed. Added tests to verify this behavior.
✅ Verification: Run `PYTHONPATH=.:.github/scripts pytest tests/test_code_health_scanner.py -v`. All tests, including the new `test_read_file_safe_path_types`, will pass.

---
*PR created automatically by Jules for task [1596571904375437778](https://jules.google.com/task/1596571904375437778) started by @abhimehro*