### PR TITLE
Autofix(): Daily QA Review - Styler and Linter fixes

### DIFF
--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -63,16 +63,20 @@ validate_sensor_file <- function(file_path) {
   # ⚡ Bolt: file.size() is ~3-4x faster than file.info()$size
   file_size <- file.size(file_path)
   if (is.na(file_size) || file_size > max_file_size) {
-    stop(sprintf("File %s exceeds maximum allowed size of %d MB.",
-                 basename(file_path), max_file_size / (1024 * 1024)))
+    stop(sprintf(
+      "File %s exceeds maximum allowed size of %d MB.",
+      basename(file_path), max_file_size / (1024 * 1024)
+    ))
   }
 }
 
 # Read a single sensor data file
 read_sensor_data <- function(file_path,
                              sep = " ",
-                             verbose = getOption("seatek.read.verbose",
-                                                 interactive())) {
+                             verbose = getOption(
+                               "seatek.read.verbose",
+                               interactive()
+                             )) {
   file_path <- normalizePath(file_path)
   if (isTRUE(verbose)) {
     cat(sprintf("  📂 Reading: %s\n", basename(file_path)))
@@ -142,9 +146,10 @@ execute_tasks_parallel <- function(tasks, task_func) {
 
   if (requireNamespace("parallel", quietly = TRUE)) {
     cores_detected <- tryCatch(parallel::detectCores(),
-                               error = function(e) NA_real_)
+      error = function(e) NA_real_
+    )
     if (!is.numeric(cores_detected) || !is.finite(cores_detected) ||
-          cores_detected < 1) {
+      cores_detected < 1) {
       cores <- 1L
     } else {
       cores <- max(1L, as.integer(cores_detected) - 1L)
@@ -159,8 +164,10 @@ execute_tasks_parallel <- function(tasks, task_func) {
     out_files
   } else {
     out_files <- vector("list", length(tasks))
-    pb_write <- txtProgressBar(min = 0, max = length(tasks),
-                               style = 3, char = "█")
+    pb_write <- txtProgressBar(
+      min = 0, max = length(tasks),
+      style = 3, char = "█"
+    )
     tryCatch(
       {
         for (i in seq_along(tasks)) {
@@ -244,7 +251,8 @@ export_raw_data_parallel <- function(raw_export_tasks) {
 
     out_files <- execute_tasks_parallel(raw_export_tasks, write_task)
     message(paste0(sprintf("Raw data written to %s", out_files),
-                   collapse = "\n"))
+      collapse = "\n"
+    ))
   }
 }
 
@@ -256,8 +264,10 @@ process_all_data <- function(data_dir) {
   if (length(files) == 0) {
     stop(sprintf("No sensor files found matching %s in %s", pattern, data_dir))
   }
-  cat(sprintf("\n🚀 Found %d sensor files. Starting processing...\n",
-              length(files)))
+  cat(sprintf(
+    "\n🚀 Found %d sensor files. Starting processing...\n",
+    length(files)
+  ))
   # ⚡ Bolt: Pre-allocate lists to avoid O(N^2) memory reallocation overhead
   # in loops
   results <- vector("list", length(files))
@@ -291,8 +301,10 @@ process_all_data <- function(data_dir) {
   }
   close(pb)
   names(results) <- sheet_names
-  cat(paste("\nℹ Sensor files read and metrics computed;",
-            "starting raw Excel exports...\n"))
+  cat(paste(
+    "\nℹ Sensor files read and metrics computed;",
+    "starting raw Excel exports...\n"
+  ))
 
   # ⚡ Bolt: Parallelize raw Excel writes to remove serial I/O bottleneck
   cat("\n⚡ Writing raw Excel files in parallel...\n")
@@ -313,7 +325,7 @@ write_year_sheet <- function(wb, year, data, header_style,
   freezePane(wb, sheet = year, firstRow = TRUE)
   # Optional: highlight largest within_diff in each year
   if ("within_diff" %in% colnames(data) && !is.null(highlight_style_yearly) &&
-        nrow(data) > 0 && is.numeric(data$within_diff)) {
+    nrow(data) > 0 && is.numeric(data$within_diff)) {
     max_idx <- which.max(abs(data$within_diff))
     if (length(max_idx) == 1L) {
       addStyle(wb,
@@ -375,20 +387,28 @@ calculate_summary_stats <- function(results) {
     keyby = "Sensor", .SDcols = metrics
   ]
 
-  stat_names <- c("mean", "sd", "median", "mad", "min", "max",
-                  "count", "rollmean3")
-  new_names <- c("Sensor",
-                 paste(rep(metrics, each = length(stat_names)),
-                       stat_names, sep = "_"))
+  stat_names <- c(
+    "mean", "sd", "median", "mad", "min", "max",
+    "count", "rollmean3"
+  )
+  new_names <- c(
+    "Sensor",
+    paste(rep(metrics, each = length(stat_names)),
+      stat_names,
+      sep = "_"
+    )
+  )
   setnames(summary_wide, new_names)
 
   # Calculate percent non-missing for 'full'
   # ⚡ Bolt: Direct unquoted column referencing is faster than standard
   # evaluation with get()
   if (is.data.table(summary_wide)) {
-    set(summary_wide, j = "full_pct_nonmissing", value =
-          # nolint next: object_usage_linter.
-          100 * summary_wide$full_count / length(results))
+    set(summary_wide,
+      j = "full_pct_nonmissing", value =
+      # nolint next: object_usage_linter.
+        100 * summary_wide$full_count / length(results)
+    )
   } else {
     summary_wide$full_pct_nonmissing <-
       100 * summary_wide$full_count / length(results)
@@ -464,7 +484,7 @@ export_main_summary <- function(wb, summary_df, output_file,
 
   # Highlight top N sensors with largest absolute within_diff_mean
   if ("within_diff_mean" %in% colnames(summary_df) &&
-        !is.null(highlight_style_summary)) {
+    !is.null(highlight_style_summary)) {
     abs_diff <- abs(summary_df$within_diff_mean)
     top_idx <- order(abs_diff, decreasing = TRUE)[
       seq_len(min(highlight_top_n, length(abs_diff)))
@@ -526,8 +546,10 @@ write_summary_sheets <- function(wb, summary_df, output_file,
   # evaluation with get()
   if (is.data.table(summary_df)) {
     # nolint next: object_usage_linter.
-    set(summary_df, j = "flag_high_variability",
-        value = summary_df$full_sd > sd_threshold)
+    set(summary_df,
+      j = "flag_high_variability",
+      value = summary_df$full_sd > sd_threshold
+    )
   } else {
     summary_df$flag_high_variability <- summary_df$full_sd > sd_threshold
   }
@@ -571,8 +593,10 @@ dump_summary_excel <- function(results, output_file, highlight_top_n = 5) {
     )
     i <- 0
     for (year in names(results)) {
-      write_year_sheet(wb, year, results[[year]], header_style,
-                       highlight_style_yearly)
+      write_year_sheet(
+        wb, year, results[[year]], header_style,
+        highlight_style_yearly
+      )
       i <- i + 1
       setTxtProgressBar(pb, i)
     }
@@ -619,7 +643,9 @@ handle_pipeline_warning <- function(w) {
 handle_pipeline_error <- function(e) {
   error_message <- conditionMessage(e)
   if (grepl("could not find function|Error in library|there is no package called", # nolint: line_length_linter
-            error_message, ignore.case = TRUE)) {
+    error_message,
+    ignore.case = TRUE
+  )) {
     log_handler("DEPENDENCY_ERROR", error_message)
   } else {
     log_handler("PROCESSING_ERROR", error_message)

--- a/tests/test_perf_sapply_vs_lapply.R
+++ b/tests/test_perf_sapply_vs_lapply.R
@@ -53,11 +53,11 @@ mb <- microbenchmark(
       h <- head(x, 10)
       mean(h[which(h > 0)])
     })
-    last5   <- sapply(df[, ..sensor_names], function(x) {
+    last5 <- sapply(df[, ..sensor_names], function(x) {
       t <- tail(x, 5)
       mean(t[which(t > 0)])
     })
-    full    <- sapply(df[, ..sensor_names], function(x) {
+    full <- sapply(df[, ..sensor_names], function(x) {
       mean(x[which(x > 0)])
     })
   },
@@ -67,14 +67,13 @@ mb <- microbenchmark(
     first10 <- unlist(df[1:min(10, .N), lapply(.SD, function(x) {
       mean(x[which(x > 0)])
     }), .SDcols = sensor_names])
-    last5   <- unlist(df[max(1, .N - 4):.N, lapply(.SD, function(x) {
+    last5 <- unlist(df[max(1, .N - 4):.N, lapply(.SD, function(x) {
       mean(x[which(x > 0)])
     }), .SDcols = sensor_names])
-    full    <- unlist(df[, lapply(.SD, function(x) {
+    full <- unlist(df[, lapply(.SD, function(x) {
       mean(x[which(x > 0)])
     }), .SDcols = sensor_names])
   },
-
   times = 10
 )
 

--- a/tests/testthat/test-calculate_summary_stats.R
+++ b/tests/testthat/test-calculate_summary_stats.R
@@ -17,7 +17,7 @@ test_that("calculate_summary_stats correctly aggregates multi-year data", {
   }
 
   years <- c("1995", "1996", "1997", "1998")
-  mock_results <- stats::setNames(lapply(1:length(years), function(i) mock_sensor_data(i)), years)
+  mock_results <- stats::setNames(lapply(seq_along(years), function(i) mock_sensor_data(i)), years)
 
   # Call the function being tested
   # Suppress the data.table::melt coercion warning for clean test output

--- a/tests/testthat/test-dump_summary_excel.R
+++ b/tests/testthat/test-dump_summary_excel.R
@@ -11,7 +11,7 @@ test_that("dump_summary_excel creates correct Excel and CSV files", {
   temp_dir_name <- "temp_dump_summary_test_output" # Unique name
   # testthat runs tests with the working directory set to the directory containing the test file.
   # So getwd() inside tests/testthat/test-dump_summary_excel.R will be tests/testthat
-  temp_dir_path <- file.path(getwd(), temp_dir_name) 
+  temp_dir_path <- file.path(getwd(), temp_dir_name)
 
   # Clean up before test, in case of previous failed run
   if (dir.exists(temp_dir_path)) {
@@ -26,16 +26,16 @@ test_that("dump_summary_excel creates correct Excel and CSV files", {
       Sensor = paste0("Sensor", sprintf("%02d", 1:32)),
       first10 = runif(32, 5, 15) + val_offset,
       last5 = runif(32, 5, 15) + val_offset,
-      full = runif(32, 5, 15) + val_offset, 
+      full = runif(32, 5, 15) + val_offset,
       within_diff = runif(32, -2, 2) + val_offset # within_diff can be negative
     )
   }
   # Create a list of such data.frames, named by year (5 years for Summary_Sufficient test)
   years <- as.character(1995:1999)
-  mock_results <- stats::setNames(lapply(1:length(years), function(i) mock_sensor_data(i)), years)
+  mock_results <- stats::setNames(lapply(seq_along(years), function(i) mock_sensor_data(i)), years)
 
   output_excel_file <- file.path(temp_dir_path, "test_summary_output.xlsx")
-  
+
   # Suppress messages from dump_summary_excel (like "Writing sheet...")
   suppressMessages({
     # Call the function being tested
@@ -57,43 +57,47 @@ test_that("dump_summary_excel creates correct Excel and CSV files", {
 
   # 3. Check CSV file creation
   csv_base_name <- tools::file_path_sans_ext(output_excel_file) # From tools package
-  
+
   csv_files_to_check <- c(
     paste0(csv_base_name, "_all.csv"),
     paste0(csv_base_name, "_sufficient.csv"),
     paste0(csv_base_name, "_top_sensors.csv"),
     paste0(csv_base_name, ".csv"), # Corresponds to "Summary" sheet
     paste0(csv_base_name, "_robust.csv") # Corresponds to "Summary_Robust" sheet (if created)
-                                        # The function creates "Summary_Robust" sheet and CSV
+    # The function creates "Summary_Robust" sheet and CSV
   )
-  
+
   for (csv_file_path in csv_files_to_check) {
     expect_true(file.exists(csv_file_path), info = paste("Expected CSV file not found:", csv_file_path))
     if (grepl("_sufficient.csv", csv_file_path, fixed = TRUE)) {
-        # utils::read.csv is fine
-        df_sufficient_csv <- utils::read.csv(csv_file_path)
-        expect_gt(nrow(df_sufficient_csv), 0, label = "The _sufficient.csv should not be empty.")
-        # Given 5 years of mock data and min_count=5 (default), all 32 sensors should be present.
-        expect_equal(nrow(df_sufficient_csv), 32, label = "The _sufficient.csv should contain 32 sensor rows.")
-        expect_true("Sensor" %in% colnames(df_sufficient_csv))
+      # utils::read.csv is fine
+      df_sufficient_csv <- utils::read.csv(csv_file_path)
+      expect_gt(nrow(df_sufficient_csv), 0, label = "The _sufficient.csv should not be empty.")
+      # Given 5 years of mock data and min_count=5 (default), all 32 sensors should be present.
+      expect_equal(nrow(df_sufficient_csv), 32, label = "The _sufficient.csv should contain 32 sensor rows.")
+      expect_true("Sensor" %in% colnames(df_sufficient_csv))
     }
   }
 
   # 4. Basic content check for one Excel sheet
   data_from_1995_sheet <- openxlsx::read.xlsx(output_excel_file, sheet = "1995")
-  
+
   # Compare a specific value
   original_value <- mock_results[["1995"]][Sensor == "Sensor01"]$first10
   value_from_excel <- data_from_1995_sheet[data_from_1995_sheet$Sensor == "Sensor01", "first10"]
-  expect_equal(value_from_excel, original_value, tolerance = 1e-6, 
-               label = "Data integrity check for Sensor01 first10 in 1995 sheet.")
+  expect_equal(value_from_excel, original_value,
+    tolerance = 1e-6,
+    label = "Data integrity check for Sensor01 first10 in 1995 sheet."
+  )
 
   # Check one more value from a different column and sensor for robustness
   original_value_s32_full <- mock_results[["1999"]][Sensor == "Sensor32"]$full
   data_from_1999_sheet <- openxlsx::read.xlsx(output_excel_file, sheet = "1999")
   value_from_excel_s32_full <- data_from_1999_sheet[data_from_1999_sheet$Sensor == "Sensor32", "full"]
-  expect_equal(value_from_excel_s32_full, original_value_s32_full, tolerance = 1e-6,
-               label = "Data integrity check for Sensor32 full in 1999 sheet.")
+  expect_equal(value_from_excel_s32_full, original_value_s32_full,
+    tolerance = 1e-6,
+    label = "Data integrity check for Sensor32 full in 1999 sheet."
+  )
 
   # Cleanup: Remove the temporary directory and its contents
   unlink(temp_dir_path, recursive = TRUE, force = TRUE)

--- a/tests/testthat/test-execute_tasks_parallel.R
+++ b/tests/testthat/test-execute_tasks_parallel.R
@@ -1,169 +1,177 @@
 library(testthat)
 
 test_that("execute_tasks_parallel handles empty task list", {
-    res <- execute_tasks_parallel(list(), function(x) x)
-    expect_equal(res, list())
+  res <- execute_tasks_parallel(list(), function(x) x)
+  expect_equal(res, list())
 })
 
 test_that("execute_tasks_parallel executes tasks successfully using parallel backend", {
-    tasks <- list(1, 2, 3)
-    res <- execute_tasks_parallel(tasks, function(x) x * 2)
-    expect_equal(res, list(2, 4, 6))
+  tasks <- list(1, 2, 3)
+  res <- execute_tasks_parallel(tasks, function(x) x * 2)
+  expect_equal(res, list(2, 4, 6))
 })
 
 test_that("execute_tasks_parallel falls back to serial execution gracefully", {
-    # Redefine the function body in our local env so we can control its execution context
-    local_env <- new.env(parent = globalenv())
-    local_env$execute_tasks_parallel <- execute_tasks_parallel
+  # Redefine the function body in our local env so we can control its execution context
+  local_env <- new.env(parent = globalenv())
+  local_env$execute_tasks_parallel <- execute_tasks_parallel
 
-    # Mask requireNamespace inside local_env
-    local_env$requireNamespace <- function(package, ...) {
-        if (package == "parallel") return(FALSE)
-        base::requireNamespace(package, ...)
+  # Mask requireNamespace inside local_env
+  local_env$requireNamespace <- function(package, ...) {
+    if (package == "parallel") {
+      return(FALSE)
     }
+    base::requireNamespace(package, ...)
+  }
 
-    environment(local_env$execute_tasks_parallel) <- local_env
+  environment(local_env$execute_tasks_parallel) <- local_env
 
-    tasks <- list(1, 2, 3)
+  tasks <- list(1, 2, 3)
 
-    res <- NULL
+  res <- NULL
 
-    # Run the function in the mocked environment
-    # txtProgressBar writes to the terminal, we can capture or suppress it using capture.output
-    suppressMessages(
-        capture.output({
-            res <- local_env$execute_tasks_parallel(tasks, function(x) x * 3)
-        })
-    )
+  # Run the function in the mocked environment
+  # txtProgressBar writes to the terminal, we can capture or suppress it using capture.output
+  suppressMessages(
+    capture.output({
+      res <- local_env$execute_tasks_parallel(tasks, function(x) x * 3)
+    })
+  )
 
-    expect_equal(res, list(3, 6, 9))
+  expect_equal(res, list(3, 6, 9))
 })
 
 test_that("execute_tasks_parallel handles detectCores errors gracefully", {
-    # Redefine the function body in our local env so we can control its execution context
-    local_env <- new.env(parent = globalenv())
-    local_env$execute_tasks_parallel <- execute_tasks_parallel
+  # Redefine the function body in our local env so we can control its execution context
+  local_env <- new.env(parent = globalenv())
+  local_env$execute_tasks_parallel <- execute_tasks_parallel
 
-    # We want it to use parallel namespace but intercept tryCatch or detectCores.
-    # Since tryCatch evaluates detectCores() in baseenv, masking detectCores in the function environment is hard
-    # because it specifically calls `parallel::detectCores()`.
-    # To mock a namespaced call without a mocking framework, we can redefine the function's source code text.
+  # We want it to use parallel namespace but intercept tryCatch or detectCores.
+  # Since tryCatch evaluates detectCores() in baseenv, masking detectCores in the function environment is hard
+  # because it specifically calls `parallel::detectCores()`.
+  # To mock a namespaced call without a mocking framework, we can redefine the function's source code text.
 
-    func_text <- deparse(execute_tasks_parallel)
-    func_text <- gsub("parallel::detectCores()", "stop('Mock Error')", func_text, fixed = TRUE)
+  func_text <- deparse(execute_tasks_parallel)
+  func_text <- gsub("parallel::detectCores()", "stop('Mock Error')", func_text, fixed = TRUE)
 
-    local_env$execute_tasks_parallel_mocked <- eval(parse(text = paste(func_text, collapse = "\n")))
+  local_env$execute_tasks_parallel_mocked <- eval(parse(text = paste(func_text, collapse = "\n")))
 
-    # Now it should fall back to cores=1L
-    tasks <- list(1, 2)
-    res <- local_env$execute_tasks_parallel_mocked(tasks, function(x) x * 4)
-    expect_equal(res, list(4, 8))
+  # Now it should fall back to cores=1L
+  tasks <- list(1, 2)
+  res <- local_env$execute_tasks_parallel_mocked(tasks, function(x) x * 4)
+  expect_equal(res, list(4, 8))
 })
 
 test_that("execute_tasks_parallel executes gracefully on non-unix platforms", {
-    local_env <- new.env(parent = globalenv())
+  local_env <- new.env(parent = globalenv())
 
-    # We want to force the non-unix branch: .Platform$OS.type != "unix"
-    func_text <- deparse(execute_tasks_parallel)
-    func_text <- gsub(".Platform$OS.type == \"unix\"", "FALSE", func_text, fixed = TRUE)
+  # We want to force the non-unix branch: .Platform$OS.type != "unix"
+  func_text <- deparse(execute_tasks_parallel)
+  func_text <- gsub(".Platform$OS.type == \"unix\"", "FALSE", func_text, fixed = TRUE)
 
-    local_env$execute_tasks_parallel_mocked <- eval(parse(text = paste(func_text, collapse = "\n")))
+  local_env$execute_tasks_parallel_mocked <- eval(parse(text = paste(func_text, collapse = "\n")))
 
-    tasks <- list(1, 2)
-    res <- local_env$execute_tasks_parallel_mocked(tasks, function(x) x * 5)
-    expect_equal(res, list(5, 10))
+  tasks <- list(1, 2)
+  res <- local_env$execute_tasks_parallel_mocked(tasks, function(x) x * 5)
+  expect_equal(res, list(5, 10))
 })
 
 test_that("execute_tasks_parallel serial fallback bubbles errors from task_func", {
-    local_env <- new.env(parent = globalenv())
-    local_env$execute_tasks_parallel <- execute_tasks_parallel
+  local_env <- new.env(parent = globalenv())
+  local_env$execute_tasks_parallel <- execute_tasks_parallel
 
-    local_env$requireNamespace <- function(package, ...) {
-        if (package == "parallel") return(FALSE)
-        base::requireNamespace(package, ...)
+  local_env$requireNamespace <- function(package, ...) {
+    if (package == "parallel") {
+      return(FALSE)
     }
+    base::requireNamespace(package, ...)
+  }
 
-    environment(local_env$execute_tasks_parallel) <- local_env
+  environment(local_env$execute_tasks_parallel) <- local_env
 
-    tasks <- list(1, 2, 3)
+  tasks <- list(1, 2, 3)
 
-    failing_task <- function(x) {
-        if (x == 2) stop("Task failed")
-        return(x)
-    }
+  failing_task <- function(x) {
+    if (x == 2) stop("Task failed")
+    return(x)
+  }
 
-    suppressMessages(
-        capture.output({
-            expect_error(
-                local_env$execute_tasks_parallel(tasks, failing_task),
-                "Task failed"
-            )
-        })
-    )
+  suppressMessages(
+    capture.output({
+      expect_error(
+        local_env$execute_tasks_parallel(tasks, failing_task),
+        "Task failed"
+      )
+    })
+  )
 })
 
 test_that("execute_tasks_parallel progress bar is closed on error", {
-    local_env <- new.env(parent = globalenv())
-    local_env$execute_tasks_parallel <- execute_tasks_parallel
+  local_env <- new.env(parent = globalenv())
+  local_env$execute_tasks_parallel <- execute_tasks_parallel
 
-    local_env$requireNamespace <- function(package, ...) {
-        if (package == "parallel") return(FALSE)
-        base::requireNamespace(package, ...)
+  local_env$requireNamespace <- function(package, ...) {
+    if (package == "parallel") {
+      return(FALSE)
     }
+    base::requireNamespace(package, ...)
+  }
 
-    environment(local_env$execute_tasks_parallel) <- local_env
+  environment(local_env$execute_tasks_parallel) <- local_env
 
-    # We need to capture the fact that close() was called on the progress bar.
-    # A simple way to do this is to mock close() or txtProgressBar in the local env.
+  # We need to capture the fact that close() was called on the progress bar.
+  # A simple way to do this is to mock close() or txtProgressBar in the local env.
 
-    pb_created <- FALSE
-    pb_closed <- FALSE
+  pb_created <- FALSE
+  pb_closed <- FALSE
 
-    local_env$txtProgressBar <- function(min, max, style, ...) {
-        pb_created <<- TRUE
-        structure(list(min=min, max=max), class="txtProgressBarMock")
+  local_env$txtProgressBar <- function(min, max, style, ...) {
+    pb_created <<- TRUE
+    structure(list(min = min, max = max), class = "txtProgressBarMock")
+  }
+
+  local_env$setTxtProgressBar <- function(pb, value) {
+    # do nothing
+  }
+
+  local_env$close <- function(con, ...) {
+    if (inherits(con, "txtProgressBarMock")) {
+      pb_closed <<- TRUE
+    } else {
+      base::close(con, ...)
     }
+  }
 
-    local_env$setTxtProgressBar <- function(pb, value) {
-        # do nothing
-    }
+  tasks <- list(1, 2)
+  failing_task <- function(x) {
+    if (x == 2) stop("Task 2 failed")
+    return(x)
+  }
 
-    local_env$close <- function(con, ...) {
-        if (inherits(con, "txtProgressBarMock")) {
-            pb_closed <<- TRUE
-        } else {
-            base::close(con, ...)
-        }
-    }
+  expect_error(
+    local_env$execute_tasks_parallel(tasks, failing_task),
+    "Task 2 failed"
+  )
 
-    tasks <- list(1, 2)
-    failing_task <- function(x) {
-        if (x == 2) stop("Task 2 failed")
-        return(x)
-    }
-
-    expect_error(
-        local_env$execute_tasks_parallel(tasks, failing_task),
-        "Task 2 failed"
-    )
-
-    expect_true(pb_created)
-    expect_true(pb_closed)
+  expect_true(pb_created)
+  expect_true(pb_closed)
 })
 
 test_that("execute_tasks_parallel serial fallback handles empty list gracefully", {
-    local_env <- new.env(parent = globalenv())
-    local_env$execute_tasks_parallel <- execute_tasks_parallel
+  local_env <- new.env(parent = globalenv())
+  local_env$execute_tasks_parallel <- execute_tasks_parallel
 
-    local_env$requireNamespace <- function(package, ...) {
-        if (package == "parallel") return(FALSE)
-        base::requireNamespace(package, ...)
+  local_env$requireNamespace <- function(package, ...) {
+    if (package == "parallel") {
+      return(FALSE)
     }
+    base::requireNamespace(package, ...)
+  }
 
-    environment(local_env$execute_tasks_parallel) <- local_env
+  environment(local_env$execute_tasks_parallel) <- local_env
 
-    # An empty list should be returned immediately before the txtProgressBar throws an error
-    # since max (length of tasks) would be 0, violating max > min in txtProgressBar.
-    res <- local_env$execute_tasks_parallel(list(), function(x) x)
-    expect_equal(res, list())
+  # An empty list should be returned immediately before the txtProgressBar throws an error
+  # since max (length of tasks) would be 0, violating max > min in txtProgressBar.
+  res <- local_env$execute_tasks_parallel(list(), function(x) x)
+  expect_equal(res, list())
 })

--- a/tests/testthat/test-export_main_summary.R
+++ b/tests/testthat/test-export_main_summary.R
@@ -50,7 +50,8 @@ test_that("export_main_summary works correctly", {
   # Check Excel sheet names
   sheet_names <- openxlsx::getSheetNames(output_file)
   expect_true("Summary" %in% sheet_names,
-              label = "Summary sheet must be present.")
+    label = "Summary sheet must be present."
+  )
 
   # Check CSV files creation
   csv_base_name <- tools::file_path_sans_ext(output_file)
@@ -59,7 +60,8 @@ test_that("export_main_summary works correctly", {
 
   expect_true(file.exists(csv_out), info = "Expected Summary CSV not found")
   expect_true(file.exists(csv_robust),
-              info = "Expected Robust Summary CSV not found")
+    info = "Expected Robust Summary CSV not found"
+  )
 
   # 2. Execution without within_diff_mean
   wb2 <- createWorkbook()
@@ -78,10 +80,12 @@ test_that("export_main_summary works correctly", {
   })
 
   expect_true(file.exists(output_file2),
-              label = "Excel file must be created without diff mean.")
+    label = "Excel file must be created without diff mean."
+  )
   sheet_names2 <- openxlsx::getSheetNames(output_file2)
   expect_true("Summary" %in% sheet_names2,
-              label = "Summary sheet must be present even without diff mean.")
+    label = "Summary sheet must be present even without diff mean."
+  )
 
   # 3. Execution without highlight style
   wb3 <- createWorkbook()
@@ -99,10 +103,12 @@ test_that("export_main_summary works correctly", {
   })
 
   expect_true(file.exists(output_file3),
-              label = "Excel file must be created without highlight style.")
+    label = "Excel file must be created without highlight style."
+  )
   sheet_names3 <- openxlsx::getSheetNames(output_file3)
   expect_true("Summary" %in% sheet_names3,
-              label = "Summary sheet must be present without highlight style.")
+    label = "Summary sheet must be present without highlight style."
+  )
 
   # Cleanup
   unlink(temp_dir_path, recursive = TRUE, force = TRUE)

--- a/tests/testthat/test-export_summary_sheet_and_csv.R
+++ b/tests/testthat/test-export_summary_sheet_and_csv.R
@@ -5,9 +5,9 @@ library(data.table)
 env <- globalenv()
 
 if (file.exists("../../Updated_Seatek_Analysis.R")) {
-  source("../../Updated_Seatek_Analysis.R", local=env)
+  source("../../Updated_Seatek_Analysis.R", local = env)
 } else if (file.exists("Updated_Seatek_Analysis.R")) {
-  source("Updated_Seatek_Analysis.R", local=env)
+  source("Updated_Seatek_Analysis.R", local = env)
 } else {
   stop("Main analysis script not found.")
 }

--- a/tests/testthat/test-export_top_sensors_summary.R
+++ b/tests/testthat/test-export_top_sensors_summary.R
@@ -5,9 +5,9 @@ library(data.table)
 env <- globalenv()
 
 if (file.exists("../../Updated_Seatek_Analysis.R")) {
-  source("../../Updated_Seatek_Analysis.R", local=env)
+  source("../../Updated_Seatek_Analysis.R", local = env)
 } else if (file.exists("Updated_Seatek_Analysis.R")) {
-  source("Updated_Seatek_Analysis.R", local=env)
+  source("Updated_Seatek_Analysis.R", local = env)
 } else {
   stop("Main analysis script not found.")
 }

--- a/tests/testthat/test-log_handler.R
+++ b/tests/testthat/test-log_handler.R
@@ -13,14 +13,17 @@ test_that("log_handler writes formatted messages to log_file", {
   # Temporarily override log_file
   assign("log_file", temp_log, envir = environment(log_handler))
 
-  on.exit({
-    # Restore the original log_file value
-    assign("log_file", original_log_file, envir = environment(log_handler))
-    # Cleanup temporary file
-    if (file.exists(temp_log)) {
-      suppressWarnings(file.remove(temp_log))
-    }
-  }, add = TRUE)
+  on.exit(
+    {
+      # Restore the original log_file value
+      assign("log_file", original_log_file, envir = environment(log_handler))
+      # Cleanup temporary file
+      if (file.exists(temp_log)) {
+        suppressWarnings(file.remove(temp_log))
+      }
+    },
+    add = TRUE
+  )
 
   # Execute log_handler
   log_handler("INFO", "This is a test info message")

--- a/tests/testthat/test-read_sensor_data.R
+++ b/tests/testthat/test-read_sensor_data.R
@@ -23,8 +23,9 @@ test_that("read_sensor_data successfully reads a valid file", {
 test_that("read_sensor_data handles non-existent files", {
   # Assuming read_sensor_data uses a specific error message format
   expect_error(read_sensor_data("data/non_existent_file.txt"),
-               "Invalid file: data/non_existent_file.txt",
-               fixed = TRUE) # Use fixed = TRUE for exact match of the error message string
+    "Invalid file: data/non_existent_file.txt",
+    fixed = TRUE
+  ) # Use fixed = TRUE for exact match of the error message string
 })
 
 test_that("read_sensor_data handles files with fewer columns", {
@@ -33,8 +34,9 @@ test_that("read_sensor_data handles files with fewer columns", {
   # Expect a specific warning message from the function
   expected_warning_msg <- "File SS_Y02_invalid_cols.txt has only 11 columns; expected >=33."
   expect_warning(dt <- read_sensor_data(invalid_cols_file),
-                 expected_warning_msg,
-                 fixed = TRUE)
+    expected_warning_msg,
+    fixed = TRUE
+  )
 
   expect_true(is.data.table(dt), info = "Return type should be data.table even with fewer columns")
   # The function should read all available columns and name them sequentially
@@ -68,12 +70,14 @@ test_that("read_sensor_data correctly converts numeric timestamps", {
   # We should compare the numeric value to avoid timezone printing issues.
   expected_first_timestamp_numeric <- 1609459200
   expect_equal(as.numeric(dt$Timestamp[1]), expected_first_timestamp_numeric,
-               info = "First timestamp numeric value should match input")
+    info = "First timestamp numeric value should match input"
+  )
 
   # Check all timestamps
   original_timestamps <- c(1609459200, 1609459260, 1609459320)
   expect_equal(as.numeric(dt$Timestamp), original_timestamps,
-               info = "All timestamp numeric values should match input")
+    info = "All timestamp numeric values should match input"
+  )
 })
 
 # Example of a more focused test for a specific part, if needed:
@@ -94,9 +98,12 @@ test_that("read_sensor_data enforces the 50MB maximum file size limit", {
   close(f)
 
   # Ensure cleanup happens even if the test fails
-  on.exit({
-    suppressWarnings(file.remove(large_file))
-  }, add = TRUE)
+  on.exit(
+    {
+      suppressWarnings(file.remove(large_file))
+    },
+    add = TRUE
+  )
 
   # Should throw an error about maximum allowed size
   expect_error(
@@ -112,10 +119,13 @@ test_that("fread error is caught in read_sensor_data", {
 
   # Ensure file is cleaned up and permissions restored so tempfile can delete it,
   # even if the test is skipped.
-  on.exit({
-    Sys.chmod(test_file, "644")
-    suppressWarnings(file.remove(test_file))
-  }, add = TRUE)
+  on.exit(
+    {
+      Sys.chmod(test_file, "644")
+      suppressWarnings(file.remove(test_file))
+    },
+    add = TRUE
+  )
 
   # Make the file unreadable to trigger an fread error
   Sys.chmod(test_file, "000")

--- a/tests/testthat/test-run_pipeline.R
+++ b/tests/testthat/test-run_pipeline.R
@@ -17,10 +17,13 @@ test_that("run_pipeline handles missing data directory correctly", {
   # Inject the mock
   assign("log_handler", mock_log_handler, envir = environment(run_pipeline))
 
-  on.exit({
-    # Reset log handler to its original state (if we saved it, but source() does it on load anyway)
-    # However we're in local=TRUE so it modifies the current env.
-  }, add = TRUE)
+  on.exit(
+    {
+      # Reset log handler to its original state (if we saved it, but source() does it on load anyway)
+      # However we're in local=TRUE so it modifies the current env.
+    },
+    add = TRUE
+  )
 
   # Run pipeline from a temp dir where 'Data' does not exist
   temp_dir <- tempdir()

--- a/tests/testthat/test-sapply_vs_lapply_equivalence.R
+++ b/tests/testthat/test-sapply_vs_lapply_equivalence.R
@@ -20,11 +20,11 @@ test_that("lapply(.SD) optimization produces exact same results as sapply baseli
     h <- head(x, 10)
     mean(h[which(h > 0)])
   })
-  baseline_last5   <- sapply(df[, ..sensor_names], function(x) {
+  baseline_last5 <- sapply(df[, ..sensor_names], function(x) {
     t <- tail(x, 5)
     mean(t[which(t > 0)])
   })
-  baseline_full    <- sapply(df[, ..sensor_names], function(x) {
+  baseline_full <- sapply(df[, ..sensor_names], function(x) {
     mean(x[which(x > 0)])
   })
 
@@ -33,11 +33,11 @@ test_that("lapply(.SD) optimization produces exact same results as sapply baseli
     mean(x[which(x > 0)])
   }), .SDcols = sensor_names])
 
-  optimized_last5   <- unlist(df[max(1, .N - 4):.N, lapply(.SD, function(x) {
+  optimized_last5 <- unlist(df[max(1, .N - 4):.N, lapply(.SD, function(x) {
     mean(x[which(x > 0)])
   }), .SDcols = sensor_names])
 
-  optimized_full    <- unlist(df[, lapply(.SD, function(x) {
+  optimized_full <- unlist(df[, lapply(.SD, function(x) {
     mean(x[which(x > 0)])
   }), .SDcols = sensor_names])
 

--- a/tests/testthat/test-validate_sensor_file.R
+++ b/tests/testthat/test-validate_sensor_file.R
@@ -38,10 +38,13 @@ test_that("validate_sensor_file errors on oversized file", {
   assign("file.size", function(...) 60 * 1024 * 1024, envir = .GlobalEnv)
 
   # Ensure cleanup of the mock
-  on.exit({
-    rm(list = "file.size", envir = .GlobalEnv)
-    unlink(large_file, force = TRUE)
-  }, add = TRUE)
+  on.exit(
+    {
+      rm(list = "file.size", envir = .GlobalEnv)
+      unlink(large_file, force = TRUE)
+    },
+    add = TRUE
+  )
 
   expect_error(validate_sensor_file(large_file), "exceeds maximum allowed size")
 })

--- a/tests/testthat/test-write_year_sheet.R
+++ b/tests/testthat/test-write_year_sheet.R
@@ -7,9 +7,9 @@ library(data.table)
 env <- globalenv()
 
 if (file.exists("../../Updated_Seatek_Analysis.R")) {
-  source("../../Updated_Seatek_Analysis.R", local=env)
+  source("../../Updated_Seatek_Analysis.R", local = env)
 } else if (file.exists("Updated_Seatek_Analysis.R")) {
-  source("Updated_Seatek_Analysis.R", local=env)
+  source("Updated_Seatek_Analysis.R", local = env)
 } else {
   stop("Main analysis script not found.")
 }
@@ -65,8 +65,8 @@ test_that("write_year_sheet works correctly", {
   found_highlight <- FALSE
   for (obj in style_objs) {
     if (obj$sheet == year && 3 %in% obj$rows && 5 %in% obj$cols) {
-       found_highlight <- TRUE
-       break
+      found_highlight <- TRUE
+      break
     }
   }
   expect_true(found_highlight, label = "Highlight style should be applied to correct cell (row 3, col 5).")

--- a/tests/testthat/testthat.R
+++ b/tests/testthat/testthat.R
@@ -5,9 +5,9 @@ library(testthat)
 env <- globalenv()
 
 if (file.exists("Updated_Seatek_Analysis.R")) {
-  source("Updated_Seatek_Analysis.R", local=env)
+  source("Updated_Seatek_Analysis.R", local = env)
 } else if (file.exists("../../Updated_Seatek_Analysis.R")) {
-  source("../../Updated_Seatek_Analysis.R", local=env)
+  source("../../Updated_Seatek_Analysis.R", local = env)
 } else {
   stop("Main analysis script not found.")
 }


### PR DESCRIPTION
## Jules Daily QA & Agentic Review - Findings

*   **R Pipeline:** Built successfully and all tests pass via `bash run_tests.sh`. Identified stylistic inconsistencies and lint warnings (e.g., `seq_linter` for `1:length()`). Autofixed issues using the `styler` package and safely converted `1:length()` patterns to `seq_along()`.
*   **Python Scripts:** Scanned `code_health_scanner.py` and automation scripts via `flake8`, `ruff`, and `pytest`. All 64 test items successfully passed.
*   **Action Taken:** Automatically fixed styler violations across the `.R` file suite to maintain repository health and code clarity.
*   **Bash Commands Used:** `bash run_tests.sh`, `python3 -m pytest`, `Rscript -e "library(styler); style_dir('.', exclude_dirs = c('renv', 'backups', 'Series_27', 'implementation'))"`, `Rscript -e "library(lintr); lint_dir('.')"`

The repository is healthy and clean. No other critical issues were found.

---
*PR created automatically by Jules for task [18068806968938629265](https://jules.google.com/task/18068806968938629265) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->