### PR TITLE
🎨 Palette: Improve CLI empty state UX for repository automation runner

### DIFF
--- a/.github/scripts/repository_automation.py
+++ b/.github/scripts/repository_automation.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
 from repository_automation_common import enforce_result, load_config
 from repository_automation_tasks import (
@@ -29,6 +30,12 @@ def main() -> int:
     )
     parser.add_argument("task")
     parser.add_argument("result_path", nargs="?")
+
+    # 🎨 Palette: Intercept bare run and show help for better DX
+    if len(sys.argv) == 1:
+        parser.print_help()
+        return 1
+
     args = parser.parse_args()
 
     if args.task == "enforce":


### PR DESCRIPTION
💡 What: Intercepts execution with no arguments (`len(sys.argv) == 1`) in `.github/scripts/repository_automation.py` to print the full help menu.

🎯 Why: The default `argparse` behavior of throwing a "missing arguments" error on a bare run provides a poor first impression and lacks guidance. By printing the help menu directly, users immediately see usage examples and available options without needing to guess the `--help` flag.

📸 Before/After:
Before:
```bash
$ python3 .github/scripts/repository_automation.py
usage: repository_automation.py [-h] task [result_path]
repository_automation.py: error: the following arguments are required: task
```

After:
```bash
$ python3 .github/scripts/repository_automation.py
usage: repository_automation.py [-h] task [result_path]

Consolidated repository automation runner

positional arguments:
  task
  result_path

options:
  -h, --help   show this help message and exit
```

♿ Accessibility: N/A - Developer Experience (DX) improvement.

---
*PR created automatically by Jules for task [18222884894860315498](https://jules.google.com/task/18222884894860315498) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->