### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix File Read DoS via unhandled TypeError

### DIFF
--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -83,8 +83,8 @@ def read_file_safe(filepath):
     """Safely reads a file, preventing path traversal and OOM issues."""
     try:
         # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
-        # preventing unhandled exception DoS attacks.
-        if "\0" in filepath:
+        # preventing unhandled exception DoS attacks. Cast to string to prevent TypeError.
+        if "\0" in str(filepath):
             return []
 
         # SECURITY: Prevent path traversal by ensuring file is within current directory.


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `read_file_safe` function checks for null bytes using `"\0" in filepath`. If a `pathlib.Path` or similar path-like object is passed instead of a string, this raises a `TypeError` which is not caught by the surrounding try/except block (which only catches `OSError`, `UnicodeDecodeError`, and `ValueError`), causing the application to crash.
🎯 Impact: An attacker or unexpected input could cause the scanner process to crash (Denial of Service) by passing a `Path` object that triggers the unhandled `TypeError`.
🔧 Fix: Cast the `filepath` argument to a string (`str(filepath)`) before performing the null byte check, ensuring compatibility with both standard strings and `pathlib.Path` objects.
✅ Verification: Ran `ruff check`, `ruff format`, and the full test suite (`pytest tests/`) to ensure no regressions were introduced. The fix conforms to the documented security findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [3947919875185903975](https://jules.google.com/task/3947919875185903975) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->