### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Type Error when validating file paths

### DIFF
--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -84,7 +84,7 @@ def read_file_safe(filepath):
     try:
         # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
         # preventing unhandled exception DoS attacks.
-        if "\0" in filepath:
+        if "\0" in str(filepath):
             return []
 
         # SECURITY: Prevent path traversal by ensuring file is within current directory.


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Unhandled exception (TypeError) potential due to evaluating `if "\0" in filepath:` on non-string path-like objects (e.g. `pathlib.Path`), resulting in Denial of Service / crashes during file scanning.
🎯 Impact: Security scans could crash or abort unexpectedly when attempting to process certain file paths represented as `pathlib.Path` objects.
🔧 Fix: Cast `filepath` to a string (`str(filepath)`) before performing the null byte check in `read_file_safe()`.
✅ Verification: Ran `pytest tests/` and manually verified `read_file_safe` with a `pathlib.Path` object no longer throws a `TypeError`.

---
*PR created automatically by Jules for task [3824315212063373238](https://jules.google.com/task/3824315212063373238) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->