### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unhandled TypeError DoS on pathlib.Path with null bytes

### DIFF
--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -84,7 +84,7 @@ def read_file_safe(filepath):
     try:
         # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
         # preventing unhandled exception DoS attacks.
-        if "\0" in filepath:
+        if "\0" in str(filepath):
             return []
 
         # SECURITY: Prevent path traversal by ensuring file is within current directory.

--- a/tests/test_code_health_scanner.py
+++ b/tests/test_code_health_scanner.py
@@ -117,3 +117,11 @@ def test_read_file_safe_restricted_permissions():
         if os.path.exists(test_file):
             os.chmod(test_file, 0o644)
             os.remove(test_file)
+
+
+def test_read_file_safe_null_byte_pathlib():
+    import pathlib
+
+    # Attempting to read a pathlib.Path with an embedded null character should return empty list
+    # and not raise a TypeError
+    assert read_file_safe(pathlib.Path("test\0.txt")) == []


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Unhandled `TypeError` in `read_file_safe` when scanning paths containing a null byte (`\0`). If a `pathlib.Path` or other path-like object is passed to `read_file_safe`, the expression `"\0" in filepath` throws a `TypeError: argument of type 'PosixPath' is not iterable`.
🎯 Impact: An attacker could cause the codebase scanner or related security tooling to crash by forcing it to process a crafted file path, resulting in a Denial of Service (DoS) and potentially bypassing subsequent scans or validations.
🔧 Fix: Wrapped `filepath` in `str()` during the null byte check (`if "\0" in str(filepath):`).
✅ Verification: Added a unit test `test_read_file_safe_null_byte_pathlib` to ensure `read_file_safe(pathlib.Path("test\0.txt"))` safely returns an empty list without throwing an exception. Ran the full `pytest` suite locally and verified it passes.

---
*PR created automatically by Jules for task [14863804890825989163](https://jules.google.com/task/14863804890825989163) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->