### PR TITLE
⚡ Bolt: [performance improvement] Bypass S3 method dispatch overhead by using mean.default()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -415,3 +415,6 @@ when filtering missing values, check for the presence of NAs first using
 requiring no memory allocation. **Action:** When filtering missing values, use
 `if (anyNA(x)) x <- x[!is.na(x)]` instead of unconditionally subsetting with
 `!is.na(x)`.
+
+## 2025-05-24 - Bypass generic S3 method dispatch overhead in high-frequency loops
+**Learning:** In high-frequency R loops accessing dataframe columns (like `df[[col_name]]`) and calling generic methods (`mean()`), the standard evaluation incurs significant S3 method dispatch overhead. Using `.subset2(df, col_name)` avoids the `[[.data.frame` method lookup, and `mean.default()` bypasses the `mean()` generic dispatcher. **Action:** When extracting dataframe columns and computing simple vectors inside performance-critical, highly-iterative loops, use `.subset2(df, col_name)` over `[[` and call the default underlying methods (like `mean.default()`) directly to achieve a measurable execution speedup without losing code readability.

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -366,7 +366,7 @@ calculate_summary_stats <- function(results) {
       # argument to avoid redundant median calculations for measurable speedup.
       med <- median(v_val)
       list(
-        mean      = mean(v_val),
+        mean      = mean.default(v_val),
         sd        = sd(v_val),
         median    = med,
         mad       = mad(v_val, center = med),


### PR DESCRIPTION
💡 What: Replaced the standard generic `mean()` function with its default method, `mean.default()`, in the `calc_stats` function inside `Updated_Seatek_Analysis.R`.
🎯 Why: In R, `mean()` uses S3 method dispatch to determine the class of the input object before executing the corresponding function. For standard numeric vectors, directly calling `mean.default()` bypasses the method dispatch overhead, which provides a measurable execution speedup when this function is called inside large or tight loops (e.g. grouped aggregations in data.table).
📊 Impact: Reduces overhead and moderately improves execution speed for summary statistics calculations on numeric vectors.
🔬 Measurement: Run the test suite via `bash run_tests.sh` to ensure correctness is preserved, and optionally benchmark `mean(x)` vs `mean.default(x)` on large vectors.

---
*PR created automatically by Jules for task [18196277848380864663](https://jules.google.com/task/18196277848380864663) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->