### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Unhandled Exception DoS in read_file_safe for Path objects

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -227,3 +227,7 @@ working directory first (e.g. Windows). **Prevention:** Always exclusively use
 `shutil.which("executable_name")` to resolve the absolute path of system
 binaries before passing them to `subprocess` functions, and raise a clear
 exception or fail gracefully if the absolute path cannot be resolved.
+## 2025-02-28 - Unhandled Exception DoS via pathlib null-byte rejection
+**Vulnerability:** Path validation logic using `if "\0" in filepath:` crashes with a `TypeError` when given a `pathlib.Path` object instead of a string, bypassing the intended exception handling and potentially leading to a Denial of Service (DoS).
+**Learning:** `pathlib.Path` objects are not iterable in a way that allows checking for substrings with the `in` operator, meaning any defensive checks written expecting a string will throw a `TypeError` when duck-typed with `Path`.
+**Prevention:** When validating path-like objects, explicitly cast the variable to a string (`if "\0" in str(filepath):`) to ensure compatibility and prevent unhandled type errors.

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -83,8 +83,9 @@ def read_file_safe(filepath):
     """Safely reads a file, preventing path traversal and OOM issues."""
     try:
         # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
-        # preventing unhandled exception DoS attacks.
-        if "\0" in filepath:
+        # preventing unhandled exception DoS attacks. Cast to string to prevent
+        # TypeError if a pathlib.Path object is passed.
+        if "\0" in str(filepath):
             return []
 
         # SECURITY: Prevent path traversal by ensuring file is within current directory.

--- a/tests/test_code_health_scanner.py
+++ b/tests/test_code_health_scanner.py
@@ -104,6 +104,19 @@ def test_read_file_safe_null_byte():
     assert read_file_safe("test\0.txt") == []
 
 
+def test_read_file_safe_pathlib():
+    from pathlib import Path
+    test_file = "test_pathlib.txt"
+    with open(test_file, "w") as f:
+        f.write("content")
+    try:
+        # pathlib.Path object should be handled safely without TypeError
+        assert read_file_safe(Path(test_file)) == ["content"]
+    finally:
+        if os.path.exists(test_file):
+            os.remove(test_file)
+
+
 def test_read_file_safe_restricted_permissions():
     test_file = "test_restricted.txt"
     with open(test_file, "w") as f:


### PR DESCRIPTION
🚨 Severity: LOW/MEDIUM
💡 Vulnerability: `read_file_safe`'s defense against null-byte injection (`if "\0" in filepath:`) crashes with a `TypeError` if a `pathlib.Path` object is passed, causing an unhandled exception Denial of Service.
🎯 Impact: This could crash downstream services or automation processes relying on `read_file_safe` if they pass path objects.
🔧 Fix: Explicitly cast the `filepath` argument to a string (`str(filepath)`) before performing the substring check.
✅ Verification: Added `test_read_file_safe_pathlib` to verify that `read_file_safe` handles `pathlib.Path` instances gracefully without crashing. Ran full pytest suite successfully.

---
*PR created automatically by Jules for task [11838951665107217747](https://jules.google.com/task/11838951665107217747) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->