### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix null byte path validation vulnerability pattern

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -227,3 +227,9 @@ working directory first (e.g. Windows). **Prevention:** Always exclusively use
 `shutil.which("executable_name")` to resolve the absolute path of system
 binaries before passing them to `subprocess` functions, and raise a clear
 exception or fail gracefully if the absolute path cannot be resolved.
+
+## 2026-08-25 - [DoS via Unhandled Exception]
+
+**Vulnerability:** The `read_file_safe` function checked for null bytes using `if "\0" in filepath:`. In Python 3.12+, passing a string with a null byte to path functions throws a ValueError. While this check intended to prevent that, if the `filepath` argument was passed as a `pathlib.Path` object instead of a string, the `in` operator threw a `TypeError` because `PosixPath` is not iterable.
+**Learning:** Security validation functions must handle various input types robustly, particularly when interacting with the standard library's evolving type requirements. Assuming an input is always a string can introduce unhandled exception DoS vulnerabilities when other valid types (like `Path`) are provided.
+**Prevention:** Always cast variables to strings before performing string-specific checks on them, especially when validating paths for null bytes (`if "\0" in str(filepath):`).

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -84,7 +84,7 @@ def read_file_safe(filepath):
     try:
         # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
         # preventing unhandled exception DoS attacks.
-        if "\0" in filepath:
+        if "\0" in str(filepath):
             return []
 
         # SECURITY: Prevent path traversal by ensuring file is within current directory.


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Unhandled Exception DoS. The `read_file_safe` function checked for null bytes using `if "\0" in filepath:`. If `filepath` was a `pathlib.Path` object instead of a string, this raised a `TypeError`, causing an unhandled exception that could crash the scanner.
🎯 Impact: An attacker or malformed input could crash the health scanner by passing a Path object, leading to a Denial of Service.
🔧 Fix: Wrapped the `filepath` variable in `str()` before the `in` check (`if "\0" in str(filepath):`).
✅ Verification: Ran `pytest tests/test_code_health_scanner.py` successfully. Also validated manually using a test script passing a Path object. Added an entry to `.jules/sentinel.md` documenting this learning.

---
*PR created automatically by Jules for task [2285876092574627677](https://jules.google.com/task/2285876092574627677) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/seatek_analysis/pull/746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->