### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix TypeError when pathlib.Path is passed to read_file_safe

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -227,3 +227,8 @@ working directory first (e.g. Windows). **Prevention:** Always exclusively use
 `shutil.which("executable_name")` to resolve the absolute path of system
 binaries before passing them to `subprocess` functions, and raise a clear
 exception or fail gracefully if the absolute path cannot be resolved.
+
+## 2026-08-26 - [Uncaught TypeError for Non-String Paths in Null Byte Validation]
+**Vulnerability:** The `read_file_safe` function attempted to prevent unhandled exception DoS attacks by checking for embedded null bytes in `filepath` (`if '\0' in filepath:`). However, if `filepath` was provided as a `pathlib.Path` or another `os.PathLike` object rather than a string, this check raised a `TypeError: argument of type 'PosixPath' is not iterable`, undermining the DoS protection.
+**Learning:** Checking for substrings directly on variables that represent file paths assumes they are standard strings. Python 3's `pathlib.Path` objects do not support `in` for substring checks, causing exceptions that the validation routine was specifically designed to prevent.
+**Prevention:** Always cast path variables to standard strings (e.g., `str(filepath)`) before performing manual substring validation like null byte checks (`if '\0' in str(filepath):`).

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -84,7 +84,7 @@ def read_file_safe(filepath):
     try:
         # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
         # preventing unhandled exception DoS attacks.
-        if "\0" in filepath:
+        if "\0" in str(filepath):
             return []
 
         # SECURITY: Prevent path traversal by ensuring file is within current directory.


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `read_file_safe` function attempted to prevent unhandled exception DoS attacks by checking for embedded null bytes in `filepath`. However, if `filepath` was provided as a `pathlib.Path` or another `os.PathLike` object rather than a string, this check raised a `TypeError: argument of type 'PosixPath' is not iterable`, undermining the DoS protection.
🎯 Impact: An attacker or downstream code could cause the application to crash by providing a `pathlib.Path` object to `read_file_safe`.
🔧 Fix: Cast the path variable to a string first (e.g., `str(filepath)`) before performing manual substring validation like null byte checks (`if '\0' in str(filepath):`).
✅ Verification: Ran `pytest` tests on `code_health_scanner.py` successfully.

---
*PR created automatically by Jules for task [14741244476843960924](https://jules.google.com/task/14741244476843960924) started by @abhimehro*