### PR TITLE
🎨 Palette: [CLI UX] Show help on bare run for repository_automation.py

### DIFF
--- a/.github/scripts/repository_automation.py
+++ b/.github/scripts/repository_automation.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
 from repository_automation_common import enforce_result, load_config
 from repository_automation_tasks import (
@@ -29,6 +30,11 @@ def main() -> int:
     )
     parser.add_argument("task")
     parser.add_argument("result_path", nargs="?")
+
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        return 1
+
     args = parser.parse_args()
 
     if args.task == "enforce":

--- a/tests/test_repository_automation.py
+++ b/tests/test_repository_automation.py
@@ -8,6 +8,13 @@ sys.path.insert(
 from repository_automation import TASK_RUNNERS, main
 
 
+@patch("sys.argv", ["repository_automation.py"])
+def test_main_no_args(capsys):
+    assert main() == 1
+    captured = capsys.readouterr()
+    assert "usage: " in captured.err
+
+
 @patch("sys.argv", ["repository_automation.py", "unknown-task"])
 def test_main_unknown_task(capsys):
     assert main() == 1


### PR DESCRIPTION
💡 What: Intercepted bare runs (`len(sys.argv) == 1`) in `.github/scripts/repository_automation.py` to print the full help menu to `sys.stderr`.
🎯 Why: Improves CLI UX by immediately showing available commands and usage instead of a cryptic `missing arguments: task` error when the script is run without arguments.
♿ Accessibility: Provides immediate context and guidance for CLI users, reducing frustration.

---
*PR created automatically by Jules for task [10651187235885702629](https://jules.google.com/task/10651187235885702629) started by @abhimehro*