### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix TypeError DoS in path validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -227,3 +227,7 @@ working directory first (e.g. Windows). **Prevention:** Always exclusively use
 `shutil.which("executable_name")` to resolve the absolute path of system
 binaries before passing them to `subprocess` functions, and raise a clear
 exception or fail gracefully if the absolute path cannot be resolved.
+## 2026-08-26 - Fix TypeError DoS vulnerability in file path validation
+**Vulnerability:** Unhandled TypeError when checking for null bytes in pathlib.Path objects.
+**Learning:** Security checks using string operations like 'in' will crash if the input is a Path object instead of a string.
+**Prevention:** Always explicitly cast path-like objects to strings (e.g., str(filepath)) before performing string-based security validations.

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -84,7 +84,7 @@ def read_file_safe(filepath):
     try:
         # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
         # preventing unhandled exception DoS attacks.
-        if "\0" in filepath:
+        if "\0" in str(filepath):
             return []
 
         # SECURITY: Prevent path traversal by ensuring file is within current directory.


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Unhandled TypeError when validating pathlib.Path objects for null bytes
🎯 Impact: Denial of Service (DoS) if an attacker can supply a Path object containing null bytes
🔧 Fix: Cast path to string before validation
✅ Verification: Tests pass

---
*PR created automatically by Jules for task [12160974086473856487](https://jules.google.com/task/12160974086473856487) started by @abhimehro*