### PR TITLE
⚡ Bolt: Optimize S3 method dispatch for mean and median

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -415,3 +415,8 @@ when filtering missing values, check for the presence of NAs first using
 requiring no memory allocation. **Action:** When filtering missing values, use
 `if (anyNA(x)) x <- x[!is.na(x)]` instead of unconditionally subsetting with
 `!is.na(x)`.
+
+## 2025-08-27 - Bypass generic S3 method dispatch for median()
+
+**Learning:** Similar to `mean()`, calling the generic `median()` method inside high-frequency `data.table` aggregations (like `lapply(.SD, ...)` over many groups) incurs measurable S3 method dispatch overhead.
+**Action:** When calculating medians on numeric vectors in performance-critical paths, call `median.default()` directly to bypass the `UseMethod()` lookup overhead.

--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -364,9 +364,9 @@ calculate_summary_stats <- function(results) {
     } else {
       # ⚡ Bolt: Pre-calculate the median and pass it to mad() via the `center`
       # argument to avoid redundant median calculations for measurable speedup.
-      med <- median(v_val)
+      med <- median.default(v_val)
       list(
-        mean      = mean(v_val),
+        mean      = mean.default(v_val),
         sd        = sd(v_val),
         median    = med,
         mad       = mad(v_val, center = med),


### PR DESCRIPTION
💡 **What:** Optimized `mean()` and `median()` calls by explicitly using `.default` (e.g. `mean.default()` and `median.default()`) in `calc_stats` within `Updated_Seatek_Analysis.R`. Added a journal entry for the `median()` bypass learning.

🎯 **Why:** To prevent S3 method dispatch (`UseMethod()`) overhead. In R, checking for standard methods every time `mean` or `median` is called within a high-frequency grouped `data.table` operation incurs measurable latency on numeric vectors.

📊 **Impact:** Speeds up execution by skipping the generic function method lookup over millions of sensor data aggregation calls.

🔬 **Measurement:** R profiling with tools like `microbenchmark` or `profvis` comparing `median(x)` and `median.default(x)` on large arrays shows measurable gains. Verified correct calculation by running tests suite.

---
*PR created automatically by Jules for task [10449834528404790090](https://jules.google.com/task/10449834528404790090) started by @abhimehro*