### PR TITLE
autofix(): resolve python linting and missing imports

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -43,9 +43,7 @@ def _remove_heuristic_secrets(env_dict: dict[str, str]) -> None:
     """Mutates env_dict in place to remove keys matching secret heuristic."""
     sensitive_substrings = ("TOKEN", "SECRET", "KEY", "PASSWORD", "AUTH", "CRED")
     keys_to_remove = [
-        k
-        for k in env_dict.keys()
-        if any(sub in k.upper() for sub in sensitive_substrings)
+        k for k in env_dict if any(sub in k.upper() for sub in sensitive_substrings)
     ]
     for k in keys_to_remove:
         env_dict.pop(k, None)

--- a/.github/scripts/repository_automation_tasks.py
+++ b/.github/scripts/repository_automation_tasks.py
@@ -682,9 +682,9 @@ def status_icon(status: str) -> str:
 
 # ⚡ Bolt: Helper function extracted to avoid "Large Method" rule violations when
 # replacing sequential API calls with concurrent execution via ThreadPoolExecutor.
-def fetch_daily_report_data() -> (
-    tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]
-):
+def fetch_daily_report_data() -> tuple[
+    list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]
+]:
     # ⚡ Bolt: Using ThreadPoolExecutor to run independent GitHub API calls concurrently
     # significantly reduces blocking I/O time in daily_report_lines.
     with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
@@ -783,7 +783,7 @@ def run_daily_status_report(config: dict[str, Any]) -> dict[str, Any]:
 # ⚡ Bolt: Pre-compile regular expressions to prevent redundant pattern compilation
 # overhead on every invocation, particularly in loops over issues.
 STATUS_MARKER_PATTERN = re.compile(
-    r"<!-- repository-automation:task-status\n(.*?)\n-->", re.S
+    r"<!-- repository-automation:task-status\n(.*?)\n-->", re.DOTALL
 )
 
 

--- a/Series_27/Analysis/outlier_analysis_series27.py
+++ b/Series_27/Analysis/outlier_analysis_series27.py
@@ -347,7 +347,7 @@ def _load_and_validate_file(input_file):
     try:
         with open(input_file, "rb") as f:
             file_buffer = f.read(MAX_FILE_SIZE + 1)
-    except IOError as e:
+    except OSError as e:
         logging.error(f"Error reading input file {input_file}: {e}")
         return None
 

--- a/Series_27/Analysis/test_outlier_analysis_series27.py
+++ b/Series_27/Analysis/test_outlier_analysis_series27.py
@@ -208,9 +208,9 @@ def test_apply_corrections_path_traversal(tmp_path):
         assert "outside_traversal_target" in filename
 
         # Defense-in-depth: resolved path must remain within output_dir
-        assert os.path.realpath(out_file).startswith(
-            os.path.realpath(output_dir)
-        ), f"Output path {out_file} escapes {output_dir}"
+        assert os.path.realpath(out_file).startswith(os.path.realpath(output_dir)), (
+            f"Output path {out_file} escapes {output_dir}"
+        )
 
         # The corrections summary should also reference the safe path
         assert not result.empty

--- a/tests/test_refactoring_agent_workflow.py
+++ b/tests/test_refactoring_agent_workflow.py
@@ -93,7 +93,7 @@ def test_prepare_command_extracts_first_cs_agent_line_from_multiline_comment(tmp
     )  # nosec B101
     assert "second-command-should-be-ignored" not in result.stdout  # nosec B101
     assert github_output.read_text(encoding="utf-8") == (  # nosec B101
-        "command<<EOF\n" "/cs-agent skill:fix-code-health-degradations\n" "EOF\n"
+        "command<<EOF\n/cs-agent skill:fix-code-health-degradations\nEOF\n"
     )
 
 

--- a/tests/test_repository_automation_common.py
+++ b/tests/test_repository_automation_common.py
@@ -7,7 +7,6 @@ sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.github/scripts"))
 )
 from repository_automation_common import (
-    BASH_BIN,
     _remove_heuristic_secrets,
     command_env,
     filter_env_securely,

--- a/tests/test_repository_automation_tasks.py
+++ b/tests/test_repository_automation_tasks.py
@@ -6,7 +6,6 @@ sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.github/scripts"))
 )
 import tempfile
-from pathlib import Path
 
 from repository_automation_tasks import (
     _hotspot_line_count,


### PR DESCRIPTION
This PR resolves formatting and python linting issues in `.github/scripts`, `Series_27` and `tests/` across the project using `ruff` as part of the daily automated QA review.

### What:
- Removed unused imports (e.g. `BASH_BIN`, `pathlib.Path`).
- Cleaned up implicit string concatenations and formatted the python files.

### Why:
- These fixes resolve the `ruff` linting errors, reducing codebase clutter and technical debt in CI testing environments.

---
*PR created automatically by Jules for task [5687131949216783372](https://jules.google.com/task/5687131949216783372) started by @abhimehro*