### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix TypeError in path validation for Path objects

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -227,3 +227,7 @@ working directory first (e.g. Windows). **Prevention:** Always exclusively use
 `shutil.which("executable_name")` to resolve the absolute path of system
 binaries before passing them to `subprocess` functions, and raise a clear
 exception or fail gracefully if the absolute path cannot be resolved.
+## 2025-05-06 - Prevent TypeError on null-byte checks with Path objects
+**Vulnerability:** The null-byte check `if "\0" in filepath` causes an unhandled `TypeError` (resulting in potential DoS) if `filepath` is provided as a `pathlib.Path` or other non-string path-like object, as Path objects are not iterable in this context.
+**Learning:** File path validation must account for different types of path-like objects being passed into functions, as relying on implicit string coercion for operations like `in` can lead to runtime crashes.
+**Prevention:** When manually validating file paths for embedded null bytes or substrings, always cast the path variable to a string first (e.g., `str(filepath)`) before performing the check.

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -84,7 +84,7 @@ def read_file_safe(filepath):
     try:
         # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
         # preventing unhandled exception DoS attacks.
-        if "\0" in filepath:
+        if "\0" in str(filepath):
             return []
 
         # SECURITY: Prevent path traversal by ensuring file is within current directory.


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The explicit null-byte check `if "\0" in filepath` assumes `filepath` is a string or iterable. If `read_file_safe()` is invoked with a `pathlib.Path` object (common in modern Python), this raises an unhandled `TypeError` (e.g., `argument of type 'PosixPath' is not iterable`), which can be weaponized as an application crash or Denial of Service (DoS) attack depending on the calling context.
🎯 Impact: Unhandled exceptions during file path validation can lead to application crashes, failing secure open logic, and potential DoS vectors.
🔧 Fix: Explicitly cast `filepath` to a string (`str(filepath)`) before performing the null-byte substring check, ensuring safe operation regardless of whether a string or Path object is provided.
✅ Verification: Ran `ruff check`, `ruff format`, Python tests via `pytest`, and R tests via `bash run_tests.sh`. All passed. Also manually verified the behavior of `"\0" in str(Path('...'))` in the terminal.

Added an entry to the `.jules/sentinel.md` journal capturing this learning.

---
*PR created automatically by Jules for task [9285348239918496747](https://jules.google.com/task/9285348239918496747) started by @abhimehro*