### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability when pathlib.Path is passed to read_file_safe

### DIFF
--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -84,6 +84,7 @@ def read_file_safe(filepath):
     try:
         # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
         # preventing unhandled exception DoS attacks.
+        filepath = str(filepath)
         if "\0" in filepath:
             return []
 

--- a/tests/test_code_health_scanner.py
+++ b/tests/test_code_health_scanner.py
@@ -104,6 +104,12 @@ def test_read_file_safe_null_byte():
     assert read_file_safe("test\0.txt") == []
 
 
+def test_read_file_safe_pathlib_path():
+    import pathlib
+    # Attempting to read a pathlib.Path should work without raising a TypeError
+    assert read_file_safe(pathlib.Path("non_existent_file_12345.txt")) == []
+
+
 def test_read_file_safe_restricted_permissions():
     test_file = "test_restricted.txt"
     with open(test_file, "w") as f:


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `read_file_safe` function checks `if "\0" in filepath` to prevent unhandled exception DoS attacks. However, this raises a `TypeError` if a `pathlib.Path` object is passed (in Python 3.12+), which can cause the process to crash (DoS).
🎯 Impact: If the scanner is integrated into a pipeline where paths are dynamically generated as `pathlib.Path` objects (which is increasingly common), providing a file path (even a valid one) would crash the scanner, causing a Denial of Service.
🔧 Fix: Cast `filepath` to a string before executing the null-byte check (`filepath = str(filepath)`). This ensures the check works regardless of whether the input is a string or a `Path` object. Added a unit test to verify this behavior.
✅ Verification: Ran `pytest tests/test_code_health_scanner.py` and the full suite (`bash run_tests.sh`), all tests pass.

═════ ELIR ═════
PURPOSE: Fixes a bug where passing `pathlib.Path` to `read_file_safe` caused a `TypeError` during the null byte check.
SECURITY: Prevents application crashes (DoS) when the scanner is fed `Path` objects.
FAILS IF: A non-stringifiable object is passed to `read_file_safe`.
VERIFY: The new unit test `test_read_file_safe_pathlib_path` passes.
MAINTAIN: Keep `filepath = str(filepath)` early in the function to normalize input types.

---
*PR created automatically by Jules for task [18322289018641331348](https://jules.google.com/task/18322289018641331348) started by @abhimehro*