### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix TypeError in null-byte path validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -227,3 +227,9 @@ working directory first (e.g. Windows). **Prevention:** Always exclusively use
 `shutil.which("executable_name")` to resolve the absolute path of system
 binaries before passing them to `subprocess` functions, and raise a clear
 exception or fail gracefully if the absolute path cannot be resolved.
+
+## 2026-08-28 - [Path Handling TypeError DoS]
+
+**Vulnerability:** The `read_file_safe` function in `code_health_scanner.py` attempted to validate file paths for embedded null bytes using `if "\0" in filepath:`. However, if the `filepath` argument was provided as a `pathlib.Path` object instead of a string, this check raised an unhandled `TypeError` (as `PosixPath` is not iterable for substring checks), which could lead to an application crash or Denial of Service when processing untrusted inputs.
+**Learning:** Python 3 robustly types path objects, and implicit string conversions do not occur during substring checks. Security wrappers that accept generic file paths must be resilient against both standard strings and path-like objects to prevent unhandled exceptions.
+**Prevention:** Always explicitly cast path variables to strings (e.g., `str(filepath)`) before performing string-based security validations like null-byte checks, ensuring the validation logic operates safely regardless of the input type.

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -84,7 +84,7 @@ def read_file_safe(filepath):
     try:
         # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
         # preventing unhandled exception DoS attacks.
-        if "\0" in filepath:
+        if "\0" in str(filepath):
             return []
 
         # SECURITY: Prevent path traversal by ensuring file is within current directory.


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `read_file_safe` function attempted to check for embedded null bytes in the `filepath` argument using `if "\0" in filepath:`. If a `pathlib.Path` object was passed instead of a string, this raised a `TypeError`, potentially causing an application crash or DoS when handling untrusted input.
🎯 Impact: Unhandled exception leading to a Denial of Service when processing untrusted file paths.
🔧 Fix: Explicitly cast the `filepath` variable to a string (`str(filepath)`) before performing the substring check.
✅ Verification: Ran the full Python and R test suites (`pytest` and `run_tests.sh`) to ensure the scanner functions correctly and no regressions were introduced.

═════ ELIR ═════
PURPOSE: Casts the path variable to a string before checking for null bytes in `read_file_safe`.
SECURITY: Prevents unhandled exceptions (TypeError) when the input is a `path-like` object instead of a string, averting a potential DoS.
FAILS IF: The cast fails or the underlying logic is removed.
VERIFY: Ensure `code_health_scanner.py` functions correctly with both string and `Path` object inputs.
MAINTAIN: When performing string-based validations on file paths, always ensure the input is cast to a string first.

---
*PR created automatically by Jules for task [3977621729364256187](https://jules.google.com/task/3977621729364256187) started by @abhimehro*