### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Unhandled Exception DoS in File Scanner

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -227,3 +227,8 @@ working directory first (e.g. Windows). **Prevention:** Always exclusively use
 `shutil.which("executable_name")` to resolve the absolute path of system
 binaries before passing them to `subprocess` functions, and raise a clear
 exception or fail gracefully if the absolute path cannot be resolved.
+
+## 2024-08-29 - [Unhandled Exception DoS via Path-Like Objects]
+**Vulnerability:** The `read_file_safe` function performed a null byte check (`if "\0" in filepath`) directly on the input argument without coercing it to a string. If a non-string iterable or non-iterable path-like object (e.g. `pathlib.Path`) was passed, this check could raise a `TypeError` (e.g. `TypeError: argument of type 'PosixPath' is not iterable`), crashing the scanner and creating an unhandled exception Denial of Service condition.
+**Learning:** Security checks that perform string operations (like `in`) on variables expected to be file paths must account for Python's duck typing and the common use of `pathlib.Path` or other path-like objects. Failing to do so can transform a security check into a DoS vector.
+**Prevention:** Always cast variables representing paths to strings (e.g., `str(filepath)`) before performing manual string-based security validation like null byte or substring checks.

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -84,7 +84,7 @@ def read_file_safe(filepath):
     try:
         # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
         # preventing unhandled exception DoS attacks.
-        if "\0" in filepath:
+        if "\0" in str(filepath):
             return []
 
         # SECURITY: Prevent path traversal by ensuring file is within current directory.

--- a/tests/test_code_health_scanner.py
+++ b/tests/test_code_health_scanner.py
@@ -104,6 +104,21 @@ def test_read_file_safe_null_byte():
     assert read_file_safe("test\0.txt") == []
 
 
+def test_read_file_safe_pathlib_path():
+    import pathlib
+
+    test_file = "test_pathlib.txt"
+    content = "line1\nline2\n"
+    with open(test_file, "w") as f:
+        f.write(content)
+    try:
+        read_lines = read_file_safe(pathlib.Path(test_file))
+        assert read_lines == ["line1\n", "line2\n"]
+    finally:
+        if os.path.exists(test_file):
+            os.remove(test_file)
+
+
 def test_read_file_safe_restricted_permissions():
     test_file = "test_restricted.txt"
     with open(test_file, "w") as f:

--- a/tests/test_code_health_scanner.py
+++ b/tests/test_code_health_scanner.py
@@ -1,6 +1,9 @@
 import os
+import pathlib
 import subprocess
 from unittest.mock import patch
+
+import pytest
 
 from code_health_scanner import (
     MAX_FILE_SIZE,
@@ -45,17 +48,20 @@ def test_get_repo_info_failure():
         assert commit_hash == "unknown"
 
 
-def test_read_file_safe_happy_path():
-    test_file = "test_happy.txt"
+@pytest.mark.parametrize(
+    "path_converter,filename",
+    [(str, "test_happy.txt"), (pathlib.Path, "test_pathlib.txt")],
+)
+def test_read_file_safe_happy_path(path_converter, filename):
     content = "line1\nline2\n"
-    with open(test_file, "w") as f:
+    with open(filename, "w") as f:
         f.write(content)
     try:
-        read_lines = read_file_safe(test_file)
+        read_lines = read_file_safe(path_converter(filename))
         assert read_lines == ["line1\n", "line2\n"]
     finally:
-        if os.path.exists(test_file):
-            os.remove(test_file)
+        if os.path.exists(filename):
+            os.remove(filename)
 
 
 def test_read_file_safe_path_traversal():
@@ -102,21 +108,6 @@ def test_read_file_safe_null_byte():
     # Attempting to read a file with an embedded null character should return empty list
     # and not raise a ValueError (ValueError: lstat: embedded null character in path)
     assert read_file_safe("test\0.txt") == []
-
-
-def test_read_file_safe_pathlib_path():
-    import pathlib
-
-    test_file = "test_pathlib.txt"
-    content = "line1\nline2\n"
-    with open(test_file, "w") as f:
-        f.write(content)
-    try:
-        read_lines = read_file_safe(pathlib.Path(test_file))
-        assert read_lines == ["line1\n", "line2\n"]
-    finally:
-        if os.path.exists(test_file):
-            os.remove(test_file)
 
 
 def test_read_file_safe_restricted_permissions():


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `read_file_safe` performs a null byte check (`if "\0" in filepath`) directly on the input. When passed a `pathlib.Path` object, this raises a `TypeError` because `PosixPath` is not iterable in this context, crashing the scanner (Unhandled Exception DoS).
🎯 Impact: Attackers or malformed internal automation passing path-like objects instead of strings could crash the security scanner, bypassing further checks.
🔧 Fix: Cast `filepath` to string (`str(filepath)`) before performing the null byte check.
✅ Verification: Added `test_read_file_safe_pathlib_path` to ensure `pathlib.Path` objects are handled correctly. Ran `pytest tests/` and all passed.

---
*PR created automatically by Jules for task [8997477884448173737](https://jules.google.com/task/8997477884448173737) started by @abhimehro*