### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unhandled TypeError crash vector in file reading

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -227,3 +227,7 @@ working directory first (e.g. Windows). **Prevention:** Always exclusively use
 `shutil.which("executable_name")` to resolve the absolute path of system
 binaries before passing them to `subprocess` functions, and raise a clear
 exception or fail gracefully if the absolute path cannot be resolved.
+## 2025-10-24 - [Null Byte Handling Crash]
+**Vulnerability:** Unhandled exception (TypeError) in `code_health_scanner.py:read_file_safe` when evaluating `"\0" in filepath` where `filepath` is a `pathlib.Path` object.
+**Learning:** Checking for substrings inside path objects without converting them to strings can cause TypeErrors, acting as an unhandled exception DoS vector for routines relying on standard input types.
+**Prevention:** Cast the variable to a string (e.g., `str(filepath)`) before performing string-specific checks like null byte scanning.

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -84,7 +84,7 @@ def read_file_safe(filepath):
     try:
         # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
         # preventing unhandled exception DoS attacks.
-        if "\0" in filepath:
+        if "\0" in str(filepath):
             return []
 
         # SECURITY: Prevent path traversal by ensuring file is within current directory.

--- a/tests/test_code_health_scanner.py
+++ b/tests/test_code_health_scanner.py
@@ -117,3 +117,18 @@ def test_read_file_safe_restricted_permissions():
         if os.path.exists(test_file):
             os.chmod(test_file, 0o644)
             os.remove(test_file)
+
+
+def test_read_file_safe_pathlib_path():
+    import pathlib
+
+    test_file = "test_pathlib.txt"
+    content = "line1\nline2\n"
+    with open(test_file, "w") as f:
+        f.write(content)
+    try:
+        read_lines = read_file_safe(pathlib.Path(test_file))
+        assert read_lines == ["line1\n", "line2\n"]
+    finally:
+        if os.path.exists(test_file):
+            os.remove(test_file)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Unhandled exception (TypeError) in `code_health_scanner.py:read_file_safe` when evaluating `"\0" in filepath` where `filepath` is a `pathlib.Path` object.
🎯 Impact: This acts as an unhandled exception DoS vector for routines relying on standard input types.
🔧 Fix: Cast the variable to a string (e.g., `str(filepath)`) before performing string-specific checks like null byte scanning.
✅ Verification: `pytest tests/test_code_health_scanner.py` passes successfully, validating both happy paths and restricted permissions, including the new `pathlib.Path` test.

═════ ELIR ═════
PURPOSE: Fixes an unhandled TypeError when checking for null bytes in a pathlib.Path object.
SECURITY: Prevents a potential DoS via unhandled exceptions.
FAILS IF: A non-string path object is passed without being cast to a string first.
VERIFY: Tests pass and read_file_safe gracefully handles pathlib.Path objects.
MAINTAIN: Always cast paths to strings before checking for null bytes.

---
*PR created automatically by Jules for task [2075675812112957247](https://jules.google.com/task/2075675812112957247) started by @abhimehro*