### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unhandled exception DoS risk when scanning `pathlib.Path` objects

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -227,3 +227,7 @@ working directory first (e.g. Windows). **Prevention:** Always exclusively use
 `shutil.which("executable_name")` to resolve the absolute path of system
 binaries before passing them to `subprocess` functions, and raise a clear
 exception or fail gracefully if the absolute path cannot be resolved.
+## 2025-09-02 - Securely handling path variables with null bytes
+**Vulnerability:** A file scanning utility (`read_file_safe`) checked for null bytes in the provided file path using `if "\0" in filepath:`. If `filepath` was passed as a `pathlib.Path` object instead of a string, this operation would raise a `TypeError: argument of type 'PosixPath' is not iterable`, leading to an unhandled exception DoS risk.
+**Learning:** Checking for substrings or specific characters in variables that might be objects rather than strings can cause unhandled exceptions. Path handling code often receives paths as both strings and `pathlib.Path` objects.
+**Prevention:** Always cast path variables to strings (`str(filepath)`) before performing string-specific operations like substring checks, especially for security validation logic like null byte checks.

--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -84,7 +84,8 @@ def read_file_safe(filepath):
     try:
         # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
         # preventing unhandled exception DoS attacks.
-        if "\0" in filepath:
+        # Cast to string first to handle pathlib.Path objects and prevent TypeErrors.
+        if "\0" in str(filepath):
             return []
 
         # SECURITY: Prevent path traversal by ensuring file is within current directory.


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `read_file_safe` function in `code_health_scanner.py` checked for null bytes in the provided file path using `if "\0" in filepath:`. If `filepath` was passed as a `pathlib.Path` object instead of a standard string, this operation would raise a `TypeError: argument of type 'PosixPath' is not iterable`, leading to an unhandled exception DoS risk that crashes the process.
🎯 Impact: An attacker or a misconfiguration providing a `Path` object instead of a string could cause the scanner to fail completely and halt the security checks or automation process it is part of.
🔧 Fix: Cast the `filepath` variable to a string (`str(filepath)`) before performing the string-specific substring check for the null byte. This safely accommodates both strings and `pathlib.Path` objects without throwing a `TypeError`.
✅ Verification: The fix was verified using a direct Python snippet passing `Path("test.txt")` into `read_file_safe`, which correctly evaluated and returned empty results rather than crashing. All related pytest suites pass successfully.

---
*PR created automatically by Jules for task [16911532654488643598](https://jules.google.com/task/16911532654488643598) started by @abhimehro*