### PR TITLE
chore: QA review - fix lintr style warnings

### DIFF
--- a/Updated_Seatek_Analysis.R
+++ b/Updated_Seatek_Analysis.R
@@ -131,7 +131,8 @@ read_sensor_data <- function(file_path,
     }
     if (!anyNA(num_ts)) {
       # ⚡ Bolt: Specifying tz="UTC" prevents the system timezone lookup overhead
-      # NOTE: .POSIXct skips generic as.POSIXct origin conversion for unix-epoch UTC.
+      # NOTE: .POSIXct skips generic as.POSIXct origin conversion for
+      # unix-epoch UTC.
       set(dt, j = "Timestamp", value = .POSIXct(num_ts, tz = "UTC")) # nolint: object_name_linter
     }
   }

--- a/tests/testthat/test-run_pipeline.R
+++ b/tests/testthat/test-run_pipeline.R
@@ -11,7 +11,10 @@ test_that("run_pipeline handles missing data directory correctly", {
   log_env$logs <- list()
 
   mock_log_handler <- function(level, message) {
-    log_env$logs[[length(log_env$logs) + 1]] <- list(level = level, message = message)
+    log_env$logs[[length(log_env$logs) + 1]] <- list(
+      level = level,
+      message = message
+    )
   }
 
   # Inject the mock
@@ -63,7 +66,10 @@ test_that("run_pipeline captures warnings and dependency errors", {
   log_env$logs <- list()
 
   mock_log_handler <- function(level, message) {
-    log_env$logs[[length(log_env$logs) + 1]] <- list(level = level, message = message)
+    log_env$logs[[length(log_env$logs) + 1]] <- list(
+      level = level,
+      message = message
+    )
   }
 
   assign("log_handler", mock_log_handler, envir = environment(run_pipeline))
@@ -102,7 +108,10 @@ test_that("run_pipeline executes successfully with valid data", {
   log_env$logs <- list()
 
   mock_log_handler <- function(level, message) {
-    log_env$logs[[length(log_env$logs) + 1]] <- list(level = level, message = message)
+    log_env$logs[[length(log_env$logs) + 1]] <- list(
+      level = level,
+      message = message
+    )
   }
   assign("log_handler", mock_log_handler, envir = environment(run_pipeline))
 

--- a/tests/testthat/test-sapply_vs_lapply_equivalence.R
+++ b/tests/testthat/test-sapply_vs_lapply_equivalence.R
@@ -1,54 +1,58 @@
 library(data.table)
-test_that("lapply(.SD) optimization produces exact same results as sapply baseline", {
-  # Setup synthetic data.table mimicking the benchmark data
-  set.seed(42)
-  n_rows <- 50
-  n_cols <- 5
-  sensor_names <- paste0("Sensor", sprintf("%02d", 1:n_cols))
+test_that(
+  "lapply(.SD) optimization produces exact same results as sapply baseline",
+  {
+    # Setup synthetic data.table mimicking the benchmark data
+    set.seed(42)
+    n_rows <- 50
+    n_cols <- 5
+    sensor_names <- paste0("Sensor", sprintf("%02d", 1:n_cols))
 
-  # Introduce some NAs and negatives to simulate real-world data and edge cases
-  # Done on the matrix before converting to data.table to ensure correct element-wise replacement
-  mat <- matrix(runif(n_rows * n_cols, -5, 15), nrow = n_rows)
-  mat[sample(1:(n_rows * n_cols), 20)] <- NA
-  mat[sample(1:(n_rows * n_cols), 20)] <- -1
+    # Introduce some NAs and negatives to simulate real-world data and edge cases
+    # Done on the matrix before converting to data.table to ensure correct
+    # element-wise replacement
+    mat <- matrix(runif(n_rows * n_cols, -5, 15), nrow = n_rows)
+    mat[sample(1:(n_rows * n_cols), 20)] <- NA
+    mat[sample(1:(n_rows * n_cols), 20)] <- -1
 
-  df <- data.table(mat)
-  setnames(df, sensor_names)
+    df <- data.table(mat)
+    setnames(df, sensor_names)
 
-  # --- Baseline: Using sapply with column slicing ---
-  baseline_first10 <- sapply(df[, ..sensor_names], function(x) {
-    h <- head(x, 10)
-    mean(h[which(h > 0)])
-  })
-  baseline_last5 <- sapply(df[, ..sensor_names], function(x) {
-    t <- tail(x, 5)
-    mean(t[which(t > 0)])
-  })
-  baseline_full <- sapply(df[, ..sensor_names], function(x) {
-    mean(x[which(x > 0)])
-  })
+    # --- Baseline: Using sapply with column slicing ---
+    baseline_first10 <- sapply(df[, ..sensor_names], function(x) {
+      h <- head(x, 10)
+      mean(h[which(h > 0)])
+    })
+    baseline_last5 <- sapply(df[, ..sensor_names], function(x) {
+      t <- tail(x, 5)
+      mean(t[which(t > 0)])
+    })
+    baseline_full <- sapply(df[, ..sensor_names], function(x) {
+      mean(x[which(x > 0)])
+    })
 
-  # --- Optimized: Using data.table native lapply(.SD) ---
-  optimized_first10 <- unlist(df[1:min(10, .N), lapply(.SD, function(x) {
-    mean(x[which(x > 0)])
-  }), .SDcols = sensor_names])
+    # --- Optimized: Using data.table native lapply(.SD) ---
+    optimized_first10 <- unlist(df[1:min(10, .N), lapply(.SD, function(x) {
+      mean(x[which(x > 0)])
+    }), .SDcols = sensor_names])
 
-  optimized_last5 <- unlist(df[max(1, .N - 4):.N, lapply(.SD, function(x) {
-    mean(x[which(x > 0)])
-  }), .SDcols = sensor_names])
+    optimized_last5 <- unlist(df[max(1, .N - 4):.N, lapply(.SD, function(x) {
+      mean(x[which(x > 0)])
+    }), .SDcols = sensor_names])
 
-  optimized_full <- unlist(df[, lapply(.SD, function(x) {
-    mean(x[which(x > 0)])
-  }), .SDcols = sensor_names])
+    optimized_full <- unlist(df[, lapply(.SD, function(x) {
+      mean(x[which(x > 0)])
+    }), .SDcols = sensor_names])
 
-  # --- Assertions ---
-  # Names should match
-  expect_equal(names(baseline_first10), names(optimized_first10))
-  expect_equal(names(baseline_last5), names(optimized_last5))
-  expect_equal(names(baseline_full), names(optimized_full))
+    # --- Assertions ---
+    # Names should match
+    expect_equal(names(baseline_first10), names(optimized_first10))
+    expect_equal(names(baseline_last5), names(optimized_last5))
+    expect_equal(names(baseline_full), names(optimized_full))
 
-  # Values should be identical
-  expect_equal(baseline_first10, optimized_first10)
-  expect_equal(baseline_last5, optimized_last5)
-  expect_equal(baseline_full, optimized_full)
-})
+    # Values should be identical
+    expect_equal(baseline_first10, optimized_first10)
+    expect_equal(baseline_last5, optimized_last5)
+    expect_equal(baseline_full, optimized_full)
+  }
+)

--- a/tests/testthat/test-validate_sensor_file.R
+++ b/tests/testthat/test-validate_sensor_file.R
@@ -33,9 +33,12 @@ test_that("validate_sensor_file errors on oversized file", {
   writeLines("test data", large_file)
   on.exit(unlink(large_file, force = TRUE))
 
-  # Temporarily override file.size in the global environment to simulate a large file
+  # Temporarily override file.size in the global environment to simulate
+  # a large file
   original_file_size <- base::file.size
-  assign("file.size", function(...) 60 * 1024 * 1024, envir = .GlobalEnv)
+  assign("file.size", function(...) 60 * 1024 * 1024, # nolint: object_name_linter
+    envir = .GlobalEnv
+  )
 
   # Ensure cleanup of the mock
   on.exit(

--- a/tests/testthat/test-write_summary_sheets.R
+++ b/tests/testthat/test-write_summary_sheets.R
@@ -31,7 +31,10 @@ test_that("write_summary_sheets works correctly", {
 
   output_file <- file.path(temp_dir_path, "test_summary.xlsx")
   header_style <- createStyle(textDecoration = "Bold", border = "Bottom")
-  highlight_style_summary <- createStyle(fontColour = "#9C0006", bgFill = "#FFC7CE")
+  highlight_style_summary <- createStyle(
+    fontColour = "#9C0006",
+    bgFill = "#FFC7CE"
+  )
 
   # Call the function
   suppressMessages({
@@ -50,8 +53,12 @@ test_that("write_summary_sheets works correctly", {
 
   # 2. Check Excel sheet names
   sheet_names <- openxlsx::getSheetNames(output_file)
-  expected_sheets <- c("Summary_All", "Summary_Sufficient", "Summary_Top_Sensors", "Summary")
-  expect_true(all(expected_sheets %in% sheet_names), label = "All specified Excel sheets must be present.")
+  expected_sheets <- c(
+    "Summary_All", "Summary_Sufficient", "Summary_Top_Sensors", "Summary"
+  )
+  expect_true(all(expected_sheets %in% sheet_names),
+    label = "All specified Excel sheets must be present."
+  )
 
   # 3. Check CSV files creation
   csv_base_name <- tools::file_path_sans_ext(output_file)
@@ -64,17 +71,27 @@ test_that("write_summary_sheets works correctly", {
   )
 
   for (csv_file_path in csv_files_to_check) {
-    expect_true(file.exists(csv_file_path), info = paste("Expected CSV file not found:", csv_file_path))
+    expect_true(file.exists(csv_file_path),
+      info = paste("Expected CSV file not found:", csv_file_path)
+    )
   }
 
   # 4. Check data filtering for sufficient data (full_count >= 5)
   sufficient_csv <- utils::read.csv(paste0(csv_base_name, "_sufficient.csv"))
-  expect_equal(nrow(sufficient_csv), 8, label = "Sensors with full_count >= 5 should be 8.")
+  expect_equal(nrow(sufficient_csv), 8,
+    label = "Sensors with full_count >= 5 should be 8."
+  )
 
   # 5. Check data filtering for top sensors
   top_csv <- utils::read.csv(paste0(csv_base_name, "_top_sensors.csv"))
   expect_equal(nrow(top_csv), 5, label = "Top sensors should be limited to 5.")
-  expect_true(all(c("Sensor", "within_diff_mean", "full_mean", "full_sd", "full_pct_nonmissing") %in% names(top_csv)), label = "Top sensors should have specific columns.")
+  expect_true(
+    all(c(
+      "Sensor", "within_diff_mean", "full_mean", "full_sd",
+      "full_pct_nonmissing"
+    ) %in% names(top_csv)),
+    label = "Top sensors should have specific columns."
+  )
 
   # 6. Test behavior without within_diff_mean
   wb2 <- createWorkbook()
@@ -93,9 +110,18 @@ test_that("write_summary_sheets works correctly", {
   })
 
   sheet_names2 <- openxlsx::getSheetNames(output_file2)
-  expect_false("Summary_Top_Sensors" %in% sheet_names2, label = "Summary_Top_Sensors should not be present if within_diff_mean is missing.")
-  expect_true(file.exists(paste0(tools::file_path_sans_ext(output_file2), "_all.csv")))
-  expect_false(file.exists(paste0(tools::file_path_sans_ext(output_file2), "_top_sensors.csv")))
+  expect_false("Summary_Top_Sensors" %in% sheet_names2,
+    label = "Summary_Top_Sensors should not be present if within_diff_mean is missing."
+  )
+  expect_true(
+    file.exists(paste0(tools::file_path_sans_ext(output_file2), "_all.csv"))
+  )
+  expect_false(
+    file.exists(paste0(
+      tools::file_path_sans_ext(output_file2),
+      "_top_sensors.csv"
+    ))
+  )
 
   # Cleanup
   unlink(temp_dir_path, recursive = TRUE, force = TRUE)

--- a/tests/testthat/test-write_year_sheet.R
+++ b/tests/testthat/test-write_year_sheet.R
@@ -2,7 +2,8 @@ library(testthat)
 library(openxlsx)
 library(data.table)
 
-# Use the global variables if needed, assuming the testthat.R setup has loaded them.
+# Use the global variables if needed, assuming the testthat.R setup has loaded
+# them.
 # The `Updated_Seatek_Analysis.R` contains the `write_year_sheet` function.
 env <- globalenv()
 
@@ -29,14 +30,19 @@ test_that("write_year_sheet works correctly", {
 
   # Create mock styles
   header_style <- createStyle(textDecoration = "Bold", border = "Bottom")
-  highlight_style_yearly <- createStyle(fontColour = "#006100", bgFill = "#C6EFCE")
+  highlight_style_yearly <- createStyle(
+    fontColour = "#006100",
+    bgFill = "#C6EFCE"
+  )
 
   # Call the function
   year <- "2023"
   write_year_sheet(wb, year, mock_data, header_style, highlight_style_yearly)
 
   # 1. Check if sheet was added
-  expect_true(year %in% names(wb), label = "Sheet should be added to the workbook.")
+  expect_true(year %in% names(wb),
+    label = "Sheet should be added to the workbook."
+  )
 
   # 2. Read data back and verify
   temp_file <- tempfile(fileext = ".xlsx")
@@ -45,12 +51,20 @@ test_that("write_year_sheet works correctly", {
   read_data <- read.xlsx(temp_file, sheet = year)
 
   # Verify dimensions
-  expect_equal(nrow(read_data), nrow(mock_data), label = "Number of rows should match.")
-  expect_equal(ncol(read_data), ncol(mock_data), label = "Number of columns should match.")
+  expect_equal(nrow(read_data), nrow(mock_data),
+    label = "Number of rows should match."
+  )
+  expect_equal(ncol(read_data), ncol(mock_data),
+    label = "Number of columns should match."
+  )
 
   # Verify specific values
-  expect_equal(read_data$Sensor, mock_data$Sensor, label = "Sensor column should match.")
-  expect_equal(read_data$within_diff, mock_data$within_diff, label = "within_diff column should match.")
+  expect_equal(read_data$Sensor, mock_data$Sensor,
+    label = "Sensor column should match."
+  )
+  expect_equal(read_data$within_diff, mock_data$within_diff,
+    label = "within_diff column should match."
+  )
 
   # Check that the highlight style was applied correctly
   # Find the style object for the highlight
@@ -69,18 +83,29 @@ test_that("write_year_sheet works correctly", {
       break
     }
   }
-  expect_true(found_highlight, label = "Highlight style should be applied to correct cell (row 3, col 5).")
+  expect_true(
+    found_highlight,
+    label = "Highlight style should be applied to correct cell (row 3, col 5)."
+  )
 
   # 3. Test without highlight style (should not fail)
   wb2 <- createWorkbook()
   write_year_sheet(wb2, "2024", mock_data, header_style, NULL)
-  expect_true("2024" %in% names(wb2), label = "Sheet should be added even without highlight style.")
+  expect_true("2024" %in% names(wb2),
+    label = "Sheet should be added even without highlight style."
+  )
 
-  # 4. Test without 'within_diff' column (should not fail and shouldn't try to highlight)
+  # 4. Test without 'within_diff' column (should not fail and shouldn't try to
+  # highlight)
   wb3 <- createWorkbook()
   mock_data_no_diff <- mock_data[, -c("within_diff")]
-  write_year_sheet(wb3, "2025", mock_data_no_diff, header_style, highlight_style_yearly)
-  expect_true("2025" %in% names(wb3), label = "Sheet should be added even without within_diff column.")
+  write_year_sheet(
+    wb3, "2025", mock_data_no_diff, header_style,
+    highlight_style_yearly
+  )
+  expect_true("2025" %in% names(wb3),
+    label = "Sheet should be added even without within_diff column."
+  )
 
   # Cleanup
   if (file.exists(temp_file)) file.remove(temp_file)


### PR DESCRIPTION
## Jules Daily QA & Agentic Review

### Actions Taken
- **Lintr Style Fixes**: Resolved multiple `lintr` warnings across `Updated_Seatek_Analysis.R` and several test files (`test-run_pipeline.R`, `test-sapply_vs_lapply_equivalence.R`, `test-validate_sensor_file.R`, `test-write_summary_sheets.R`, `test-write_year_sheet.R`) regarding line length and indentation.
- **Test Suite**: Verified all R tests passed after modifications using `run_tests.sh`.
- **Formatting**: Retained necessary mocked object names (e.g., `file.size`) to preserve test functionality while adding `nolint` comments where appropriate.

### Commands Used
- `bash -c 'bash run_tests.sh'`
- `Rscript -e "lintr::lint_dir('.', exclusions = list('renv/', 'backups/', 'Series_27/', 'implementation/'))"`
- `Rscript -e "library(styler); style_dir('.', exclude_dirs = c('renv', 'backups', 'Series_27', 'implementation'))"`

Repository is healthy and tests are passing.

---
*PR created automatically by Jules for task [2391597311055763973](https://jules.google.com/task/2391597311055763973) started by @abhimehro*