### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix type error handling Path objects with embedded null bytes

### DIFF
--- a/code_health_scanner.py
+++ b/code_health_scanner.py
@@ -84,7 +84,7 @@ def read_file_safe(filepath):
     try:
         # SECURITY: Handle null bytes in path which cause ValueError in Python 3.12+
         # preventing unhandled exception DoS attacks.
-        if "\0" in filepath:
+        if "\0" in str(filepath):
             return []
 
         # SECURITY: Prevent path traversal by ensuring file is within current directory.

--- a/tests/test_code_health_scanner.py
+++ b/tests/test_code_health_scanner.py
@@ -98,6 +98,22 @@ def test_get_repo_info_exception_logging(caplog):
         assert "Some hidden internal error" not in caplog.text
 
 
+def test_read_file_safe_path_object():
+    from pathlib import Path
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, dir=os.getcwd()) as f:
+        f.write("test content\n")
+        name = f.name
+
+    try:
+        read_lines = read_file_safe(Path(name))
+        assert read_lines == ["test content\n"]
+    finally:
+        if os.path.exists(name):
+            os.remove(name)
+
+
 def test_read_file_safe_null_byte():
     # Attempting to read a file with an embedded null character should return empty list
     # and not raise a ValueError (ValueError: lstat: embedded null character in path)


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** `code_health_scanner.py`'s `read_file_safe` expects a string but could receive a `pathlib.Path` object instead. When it attempted to check `"\0" in filepath`, it resulted in an unhandled exception `TypeError: argument of type 'PosixPath' is not iterable`. This would result in an unintentional DoS of the process using this file reader.
🎯 **Impact:** If code utilizing the health scanner passes path objects, it crashes abruptly, preventing further evaluation.
🔧 **Fix:** Explicitly cast `filepath` to a string `str(filepath)` before checking for a null byte (`\0`) to securely handle both String and `Path` objects. Included a test specifically targeting `pathlib.Path` objects to prevent regressions.
✅ **Verification:** A test checking for `pathlib.Path` resolution using `os.getcwd()` was added and passes.

═════ ELIR ═════
PURPOSE: Ensure `read_file_safe` can robustly handle `pathlib.Path` object inputs without raising unhandled `TypeError` exceptions.
SECURITY: Safely check for embedded null bytes before they trigger `ValueError` down the line.
FAILS IF: The passed input to `read_file_safe` cannot be safely cast to `str`.
VERIFY: Run `pytest` and verify the test case `test_read_file_safe_path_object` passes successfully.
MAINTAIN: When handling paths in functions that check for null bytes (`"\0"`), remember to check it on `str(filepath)`.

---
*PR created automatically by Jules for task [9223811308450816676](https://jules.google.com/task/9223811308450816676) started by @abhimehro*